### PR TITLE
fix: じばく・だいばくはつの防御半減効果を実装

### DIFF
--- a/src/tools/calculateDamage/handlers/helpers/calculateEvDamages.spec.ts
+++ b/src/tools/calculateDamage/handlers/helpers/calculateEvDamages.spec.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import { calculateDamageHandler } from "@/tools/calculateDamage/handlers/handler";
+
+describe("じばく・だいばくはつの防御半減", () => {
+  it("じばくで防御が半減される", async () => {
+    // 通常のわざでのダメージ計算
+    const normalInput = {
+      move: "とっしん",
+      attacker: {
+        level: 50,
+        pokemonName: "マルマイン",
+        stat: { value: 150 },
+        statModifier: 0,
+      },
+      defender: {
+        level: 50,
+        pokemonName: "カビゴン",
+        stat: { value: 200 },
+        statModifier: 0,
+      },
+      options: {},
+    };
+
+    const normalResult = await calculateDamageHandler(normalInput);
+    const normalDamageMatch =
+      normalResult.content[0].text.match(/ダメージ: (\d+) 〜 (\d+)/);
+    const normalMinDamage = Number(normalDamageMatch?.[1]);
+
+    // じばくでのダメージ計算（防御半減）
+    const selfDestructInput = {
+      move: "じばく",
+      attacker: {
+        level: 50,
+        pokemonName: "マルマイン",
+        stat: { value: 150 },
+        statModifier: 0,
+      },
+      defender: {
+        level: 50,
+        pokemonName: "カビゴン",
+        stat: { value: 200 },
+        statModifier: 0,
+      },
+      options: {},
+    };
+
+    const selfDestructResult = await calculateDamageHandler(selfDestructInput);
+    const selfDestructDamageMatch =
+      selfDestructResult.content[0].text.match(/ダメージ: (\d+) 〜 (\d+)/);
+    const selfDestructMinDamage = Number(selfDestructDamageMatch?.[1]);
+
+    // じばくは威力200で防御半減なので、とっしん（威力90）の2倍以上のダメージになるはず
+    expect(selfDestructMinDamage).toBeGreaterThan(normalMinDamage * 2);
+  });
+
+  it("だいばくはつで防御が半減される", async () => {
+    const explosionInput = {
+      move: "だいばくはつ",
+      attacker: {
+        level: 50,
+        pokemonName: "マルマイン",
+        stat: { value: 150 },
+        statModifier: 0,
+      },
+      defender: {
+        level: 50,
+        pokemonName: "カビゴン",
+        stat: { value: 200 },
+        statModifier: 0,
+      },
+      options: {},
+    };
+
+    const explosionResult = await calculateDamageHandler(explosionInput);
+    const explosionDamageMatch =
+      explosionResult.content[0].text.match(/ダメージ: (\d+) 〜 (\d+)/);
+    const explosionMinDamage = Number(explosionDamageMatch?.[1]);
+
+    // だいばくはつは威力250で防御半減なので大きなダメージになるはず
+    expect(explosionMinDamage).toBeGreaterThan(60);
+  });
+
+  it("他のわざでは防御が半減されない", async () => {
+    const hyperBeamInput = {
+      move: "はかいこうせん",
+      attacker: {
+        level: 50,
+        pokemonName: "カビゴン",
+        stat: { value: 150 },
+        statModifier: 0,
+      },
+      defender: {
+        level: 50,
+        pokemonName: "ハガネール",
+        stat: { value: 400 },
+        statModifier: 0,
+      },
+      options: {},
+    };
+
+    const hyperBeamResult = await calculateDamageHandler(hyperBeamInput);
+    const hyperBeamDamageMatch =
+      hyperBeamResult.content[0].text.match(/ダメージ: (\d+) 〜 (\d+)/);
+    const hyperBeamMaxDamage = Number(hyperBeamDamageMatch?.[2]);
+
+    // 防御が高いため、ダメージは少なめになるはず
+    expect(hyperBeamMaxDamage).toBeLessThan(50);
+  });
+});

--- a/src/tools/calculateDamage/handlers/helpers/calculateEvDamages.ts
+++ b/src/tools/calculateDamage/handlers/helpers/calculateEvDamages.ts
@@ -67,6 +67,14 @@ const calculateDamageInternal = (params: InternalDamageParams): number[] => {
     );
   }
 
+  // じばく・だいばくはつの処理: 防御を半分にする
+  if (
+    "name" in move &&
+    (move.name === "じばく" || move.name === "だいばくはつ")
+  ) {
+    defenseStat = Math.floor(defenseStat / 2);
+  }
+
   let damage = calculateBaseDamage({
     level: attacker.level,
     power: move.power,
@@ -148,6 +156,7 @@ export const calculateAttackerEvDamages = (
 
     const damages = calculateDamageInternal({
       move: {
+        name: input.move.name,
         type: input.move.type,
         power: input.move.power,
         isPhysical: input.move.isPhysical,
@@ -197,6 +206,7 @@ export const calculateDefenderEvDamages = (
 
     const damages = calculateDamageInternal({
       move: {
+        name: input.move.name,
         type: input.move.type,
         power: input.move.power,
         isPhysical: input.move.isPhysical,
@@ -241,6 +251,7 @@ export const calculateNormalDamage = (
 
   return calculateDamageInternal({
     move: {
+      name: input.move.name,
       type: input.move.type,
       power: input.move.power,
       isPhysical: input.move.isPhysical,

--- a/src/tools/calculateDamage/handlers/schemas/damageSchema/damageSchema.ts
+++ b/src/tools/calculateDamage/handlers/schemas/damageSchema/damageSchema.ts
@@ -40,6 +40,7 @@ const moveInputSchema = z.union([
   // タイプと威力を直接指定
   z
     .object({
+      name: z.string().optional(),
       type: z.enum([
         "ノーマル",
         "ほのお",

--- a/src/tools/calculateDamage/types/damageCalculation.ts
+++ b/src/tools/calculateDamage/types/damageCalculation.ts
@@ -96,6 +96,7 @@ export interface EvRangeDamageResult extends DamageCalculationContext {
  */
 export interface InternalDamageParams {
   move: {
+    name?: string;
     type: TypeName;
     power: number;
     isPhysical: boolean;


### PR DESCRIPTION
## Summary
- わざが「じばく」または「だいばくはつ」の場合、防御側のステータスを半分にしてダメージ計算を行うように実装
- 第三世代の仕様に準拠

## Changes
- `calculateDamageInternal`関数で防御値を半減する処理を追加
- `InternalDamageParams`の型定義にmove.nameを追加
- `damageSchema`でタイプと威力を直接指定する場合もnameを渡せるように修正
- テストケースを追加

## Test plan
- [x] `npm run check`が全て通過することを確認
- [x] じばくで防御が半減されることを確認するテスト
- [x] だいばくはつで防御が半減されることを確認するテスト  
- [x] 他のわざでは防御が半減されないことを確認するテスト

Closes #9