### PR TITLE
docs: CLAUDE.mdにmainブランチ保護の説明を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,6 +217,8 @@ src/
 
 - **ブランチ管理**:
   - 適宜ブランチを切り、ghコマンドを用いてプルリクを出すこと
+  - mainブランチは保護されている: 直接プッシュ不可、PR必須、CI通過必須
+  - ブランチは原則としてorigin/mainから生やす: `git checkout -b feature-branch origin/main`を使用してコンフリクトを防ぐ
 
 ## 技術スタック
 


### PR DESCRIPTION
## 概要
CLAUDE.mdの開発時のルールセクションに、mainブランチ保護とブランチ作成のルールを追記しました。

## 変更内容
- mainブランチが保護されていることを追記
  - 直接プッシュ不可
  - PR必須
  - CI通過必須
- ブランチは原則としてorigin/mainから生やすルールを追加
  - コンフリクトを防ぐためのベストプラクティス

## 背景
mainブランチに保護設定を適用したため、その内容を開発ドキュメントにも反映しました。