### PR TITLE
feat: calculate_damage_matrixツールの基盤実装 (#24)

### DIFF
--- a/src/tools/calculateDamage/handlers/helpers/calculateEvDamages/calculateEvDamages.ts
+++ b/src/tools/calculateDamage/handlers/helpers/calculateEvDamages/calculateEvDamages.ts
@@ -1,143 +1,8 @@
-import type { AbilityName } from "@/data/abilities";
-import type { ItemName } from "@/data/items";
 import type { CalculateDamageInput } from "@/tools/calculateDamage/handlers/schemas/damageSchema";
 import type {
   EvDamageEntry,
-  InternalDamageParams,
 } from "@/tools/calculateDamage/types/damageCalculation";
-import { applyAbilityEffects } from "../abilityEffects";
-import { calculateBaseDamage } from "../calculateBaseDamage";
-import { getDamageRanges } from "../damageRanges";
-import { calculateItemEffects } from "../itemEffects";
-import { getStatModifierRatio } from "../statModifier";
-import { getTypeEffectiveness } from "../typeEffectiveness";
-
-/**
- * ダメージ計算の主処理
- * 補正値、タイプ相性、とくせい効果を全て適用
- */
-const calculateDamageInternal = (params: InternalDamageParams): number[] => {
-  const { move, attacker, defender, options } = params;
-
-  const attackerItemEffects = calculateItemEffects(
-    attacker.item as ItemName | undefined,
-    attacker.pokemonName,
-    move.type,
-    move.isPhysical,
-  );
-
-  const defenderItemEffects = calculateItemEffects(
-    defender.item as ItemName | undefined,
-    defender.pokemonName,
-    move.type,
-    move.isPhysical,
-  );
-
-  const attackRatio = getStatModifierRatio(attacker.attackModifier);
-  let attackStat = Math.floor(
-    (attacker.attack * attackRatio.numerator) / attackRatio.denominator,
-  );
-
-  if (move.isPhysical) {
-    attackStat = Math.floor(
-      (attackStat * attackerItemEffects.attackMultiplier.numerator) /
-        attackerItemEffects.attackMultiplier.denominator,
-    );
-  } else {
-    attackStat = Math.floor(
-      (attackStat * attackerItemEffects.specialAttackMultiplier.numerator) /
-        attackerItemEffects.specialAttackMultiplier.denominator,
-    );
-  }
-
-  const defenseRatio = getStatModifierRatio(defender.defenseModifier);
-  let defenseStat = Math.floor(
-    (defender.defense * defenseRatio.numerator) / defenseRatio.denominator,
-  );
-
-  if (move.isPhysical) {
-    defenseStat = Math.floor(
-      (defenseStat * defenderItemEffects.defenseMultiplier.numerator) /
-        defenderItemEffects.defenseMultiplier.denominator,
-    );
-  } else {
-    defenseStat = Math.floor(
-      (defenseStat * defenderItemEffects.specialDefenseMultiplier.numerator) /
-        defenderItemEffects.specialDefenseMultiplier.denominator,
-    );
-  }
-
-  // じばく・だいばくはつの処理: 防御を半分にする
-  if (
-    "name" in move &&
-    (move.name === "じばく" || move.name === "だいばくはつ")
-  ) {
-    defenseStat = Math.floor(defenseStat / 2);
-  }
-
-  let damage = calculateBaseDamage({
-    level: attacker.level,
-    power: move.power,
-    attack: attackStat,
-    defense: defenseStat,
-    isPhysical: move.isPhysical,
-  });
-
-  if (attacker.types?.some((type) => type === move.type)) {
-    damage = Math.floor(damage * 1.5);
-  }
-
-  const typeEffectiveness = getTypeEffectiveness(move.type, defender.types);
-  damage = Math.floor(damage * typeEffectiveness);
-
-  if (options.weather === "はれ") {
-    if (move.type === "ほのお") {
-      damage = Math.floor(damage * 1.5);
-    } else if (move.type === "みず") {
-      damage = Math.floor(damage * 0.5);
-    }
-  } else if (options.weather === "あめ") {
-    if (move.type === "みず") {
-      damage = Math.floor(damage * 1.5);
-    } else if (move.type === "ほのお") {
-      damage = Math.floor(damage * 0.5);
-    }
-  }
-
-  if (options.charge && move.type === "でんき") {
-    damage = Math.floor(damage * 2);
-  }
-
-  if (move.isPhysical && options.reflect) {
-    damage = Math.floor(damage * 0.5);
-  } else if (!move.isPhysical && options.lightScreen) {
-    damage = Math.floor(damage * 0.5);
-  }
-
-  if (options.mudSport && move.type === "でんき") {
-    damage = Math.floor(damage * 0.5);
-  }
-  if (options.waterSport && move.type === "ほのお") {
-    damage = Math.floor(damage * 0.5);
-  }
-
-  damage = applyAbilityEffects({
-    damage,
-    moveType: move.type,
-    attackerAbility: attacker.ability as AbilityName | undefined,
-    defenderAbility: defender.ability as AbilityName | undefined,
-    attackerAbilityActive: attacker.abilityActive,
-    defenderAbilityActive: defender.abilityActive,
-    typeEffectiveness,
-    isPhysical: move.isPhysical,
-  });
-
-  if (damage > 0) {
-    damage = Math.max(1, damage);
-  }
-
-  return getDamageRanges(damage);
-};
+import { calculateDamageCore } from "@/tools/shared/damageCalculation";
 
 /**
  * 防御側のステータスを固定し、攻撃側のEV別ダメージを計算
@@ -154,7 +19,7 @@ export const calculateAttackerEvDamages = (
     const ev = i * 4;
     const stat = attackStatArray[i];
 
-    const damages = calculateDamageInternal({
+    const damages = calculateDamageCore({
       move: {
         name: input.move.name,
         type: input.move.type,
@@ -204,7 +69,7 @@ export const calculateDefenderEvDamages = (
     const ev = i * 4;
     const stat = defenseStatArray[i];
 
-    const damages = calculateDamageInternal({
+    const damages = calculateDamageCore({
       move: {
         name: input.move.name,
         type: input.move.type,
@@ -249,7 +114,7 @@ export const calculateNormalDamage = (
 ): number[] => {
   const defenderTypes = input.defender.pokemon?.types || [];
 
-  return calculateDamageInternal({
+  return calculateDamageCore({
     move: {
       name: input.move.name,
       type: input.move.type,

--- a/src/tools/calculateDamageMatrix/definition.ts
+++ b/src/tools/calculateDamageMatrix/definition.ts
@@ -1,0 +1,284 @@
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+
+export const calculateDamageMatrixDefinition: Tool = {
+  name: "calculate_damage_matrix",
+  title: "ポケモンダメージマトリックス計算",
+  description:
+    "防御側のステータス範囲（4〜504）に対するダメージを一括計算します。努力値の最適配分分析に最適化されたツールです。",
+  _meta: {},
+  inputSchema: {
+    type: "object",
+    properties: {
+      move: {
+        description:
+          'わざ名（文字列）、またはタイプと威力を含むオブジェクト。例: "じしん" または { type: "じめん", power: 100 }',
+        oneOf: [
+          {
+            type: "string",
+            description:
+              'わざ名（例: "じしん"、"れいとうビーム"、"10まんボルト"）',
+            examples: ["じしん", "れいとうビーム", "10まんボルト"],
+          },
+          {
+            type: "object",
+            description: "タイプと威力を指定（わざ名が不明な場合）",
+            properties: {
+              type: {
+                type: "string",
+                enum: [
+                  "ノーマル",
+                  "ほのお",
+                  "みず",
+                  "でんき",
+                  "くさ",
+                  "こおり",
+                  "かくとう",
+                  "どく",
+                  "じめん",
+                  "ひこう",
+                  "エスパー",
+                  "むし",
+                  "いわ",
+                  "ゴースト",
+                  "ドラゴン",
+                  "あく",
+                  "はがね",
+                ],
+                description: "わざのタイプ",
+              },
+              power: {
+                type: "number",
+                description: "わざの威力",
+                minimum: 1,
+                maximum: 250,
+              },
+            },
+            required: ["type", "power"],
+            additionalProperties: false,
+          },
+        ],
+      },
+      attacker: {
+        type: "object",
+        description: "攻撃側のポケモン情報",
+        properties: {
+          pokemonName: {
+            type: "string",
+            description:
+              'ポケモン名（例: "メタグロス"、"ボーマンダ"）。省略時はタイプ不一致として計算',
+            examples: ["メタグロス", "ボーマンダ", "ラティオス", "ヘラクロス"],
+          },
+          level: {
+            type: "number",
+            description: "レベル（省略時は50）",
+            default: 50,
+            minimum: 1,
+            maximum: 100,
+          },
+          stat: {
+            type: "object",
+            description: "能力値（こうげきまたはとくこう）",
+            properties: {
+              value: {
+                type: "number",
+                description: "こうげきまたはとくこうの実数値",
+                minimum: 1,
+                maximum: 999,
+              },
+            },
+            required: ["value"],
+          },
+          item: {
+            type: "string",
+            description: 'もちもの（例: "こだわりハチマキ"、"もくたん"）',
+            examples: ["こだわりハチマキ", "もくたん"],
+          },
+          ability: {
+            type: "string",
+            description: 'とくせい（例: "ちからもち"、"もうか"）',
+            examples: ["ちからもち", "もうか"],
+          },
+          abilityActive: {
+            type: "boolean",
+            description:
+              "条件付きとくせいが発動しているかどうか（もうか、げきりゅう、しんりょく等）",
+          },
+          statModifier: {
+            type: "number",
+            description:
+              "能力ランク補正（-6～+6、省略時は0）。いかく=-1、つるぎのまい=+2など",
+            default: 0,
+            minimum: -6,
+            maximum: 6,
+          },
+        },
+        required: ["stat"],
+      },
+      defenderType: {
+        type: "string",
+        enum: ["physical", "special"],
+        description: "計算する防御側のステータスタイプ（物理または特殊）",
+      },
+      defender: {
+        type: "object",
+        description: "防御側のポケモン情報（省略可能）",
+        properties: {
+          pokemonName: {
+            type: "string",
+            description:
+              'ポケモン名（例: "メタグロス"、"ボーマンダ"）。タイプ相性計算に使用',
+            examples: ["メタグロス", "ボーマンダ", "ラティオス", "ヘラクロス"],
+          },
+          level: {
+            type: "number",
+            description: "レベル（省略時は50）",
+            default: 50,
+            minimum: 1,
+            maximum: 100,
+          },
+          item: {
+            type: "string",
+            description: 'もちもの（例: "メタルパウダー"）',
+            examples: ["メタルパウダー"],
+          },
+          ability: {
+            type: "string",
+            description: 'とくせい（例: "ふしぎなうろこ"）',
+            examples: ["ふしぎなうろこ"],
+          },
+          abilityActive: {
+            type: "boolean",
+            description:
+              "条件付きとくせいが発動しているかどうか（ふしぎなうろこ等）",
+          },
+          statModifier: {
+            type: "number",
+            description:
+              "能力ランク補正（-6～+6、省略時は0）。いかく=-1など",
+            default: 0,
+            minimum: -6,
+            maximum: 6,
+          },
+        },
+      },
+      options: {
+        type: "object",
+        description: "その他のオプション",
+        properties: {
+          weather: {
+            type: "string",
+            enum: ["はれ", "あめ"],
+            description: "てんき",
+          },
+          charge: {
+            type: "boolean",
+            description: "じゅうでん",
+          },
+          reflect: {
+            type: "boolean",
+            description: "リフレクター",
+          },
+          lightScreen: {
+            type: "boolean",
+            description: "ひかりのかべ",
+          },
+          mudSport: {
+            type: "boolean",
+            description: "どろあそび",
+          },
+          waterSport: {
+            type: "boolean",
+            description: "みずあそび",
+          },
+          statRange: {
+            type: "object",
+            description: "計算する防御ステータスの範囲（省略時は4〜504）",
+            properties: {
+              min: {
+                type: "number",
+                description: "最小防御ステータス",
+                minimum: 1,
+                default: 4,
+              },
+              max: {
+                type: "number",
+                description: "最大防御ステータス",
+                maximum: 999,
+                default: 504,
+              },
+            },
+          },
+        },
+      },
+    },
+    required: ["move", "attacker", "defenderType"],
+  },
+  outputSchema: {
+    type: "object",
+    properties: {
+      move: {
+        type: "object",
+        description: "使用したわざの情報",
+        properties: {
+          name: { type: "string", description: "わざ名" },
+          type: { type: "string", description: "わざのタイプ" },
+          power: { type: "number", description: "わざの威力" },
+          category: { 
+            type: "string", 
+            enum: ["physical", "special"],
+            description: "物理/特殊の分類" 
+          },
+        },
+        required: ["type", "power", "category"],
+      },
+      attacker: {
+        type: "object",
+        description: "攻撃側の情報",
+        properties: {
+          pokemonName: { type: "string", description: "ポケモン名" },
+          level: { type: "number", description: "レベル" },
+          stat: { type: "number", description: "使用したステータス実数値" },
+        },
+        required: ["level", "stat"],
+      },
+      damageMatrix: {
+        type: "array",
+        description: "防御ステータスごとのダメージ計算結果",
+        items: {
+          type: "object",
+          properties: {
+            defenseStat: { type: "number", description: "防御側ステータス" },
+            damage: {
+              type: "object",
+              properties: {
+                min: { type: "number", description: "最小ダメージ" },
+                max: { type: "number", description: "最大ダメージ" },
+                rolls: {
+                  type: "array",
+                  description: "全16通りのダメージ値（0.85〜1.0）",
+                  items: { type: "number" },
+                  minItems: 16,
+                  maxItems: 16,
+                },
+              },
+              required: ["min", "max", "rolls"],
+            },
+          },
+          required: ["defenseStat", "damage"],
+        },
+      },
+      modifiers: {
+        type: "object",
+        description: "適用された補正",
+        properties: {
+          typeEffectiveness: { type: "number", description: "タイプ相性倍率" },
+          stab: { type: "boolean", description: "タイプ一致ボーナス適用" },
+          weather: { type: "string", description: "天候効果" },
+          ability: { type: "string", description: "適用されたとくせい" },
+          item: { type: "string", description: "適用されたもちもの" },
+        },
+      },
+    },
+    required: ["move", "attacker", "damageMatrix"],
+  },
+};

--- a/src/tools/calculateDamageMatrix/handlers/schemas/damageMatrixSchema.spec.ts
+++ b/src/tools/calculateDamageMatrix/handlers/schemas/damageMatrixSchema.spec.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect } from "vitest";
+import { calculateDamageMatrixInputSchema } from "./damageMatrixSchema";
+
+describe("calculateDamageMatrixInputSchema", () => {
+  describe("必須フィールドの検証", () => {
+    it("必須フィールドのみで有効", () => {
+      const input = {
+        move: "じしん",
+        attacker: {
+          stat: { value: 205 },
+        },
+        defenderType: "physical",
+      };
+
+      const result = calculateDamageMatrixInputSchema.safeParse(input);
+      expect(result.success).toBe(true);
+    });
+
+    it("moveがオブジェクト形式でも有効", () => {
+      const input = {
+        move: { type: "じめん", power: 100 },
+        attacker: {
+          stat: { value: 205 },
+        },
+        defenderType: "physical",
+      };
+
+      const result = calculateDamageMatrixInputSchema.safeParse(input);
+      expect(result.success).toBe(true);
+    });
+
+    it("必須フィールドが欠けている場合はエラー", () => {
+      const input = {
+        move: "じしん",
+        attacker: {
+          stat: { value: 205 },
+        },
+      };
+
+      const result = calculateDamageMatrixInputSchema.safeParse(input);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("デフォルト値の適用", () => {
+    it("levelのデフォルト値が50", () => {
+      const input = {
+        move: "じしん",
+        attacker: {
+          stat: { value: 205 },
+        },
+        defenderType: "physical",
+      };
+
+      const result = calculateDamageMatrixInputSchema.parse(input);
+      expect(result.attacker.level).toBe(50);
+    });
+
+    it("statModifierのデフォルト値が0", () => {
+      const input = {
+        move: "じしん",
+        attacker: {
+          stat: { value: 205 },
+        },
+        defenderType: "physical",
+      };
+
+      const result = calculateDamageMatrixInputSchema.parse(input);
+      expect(result.attacker.statModifier).toBe(0);
+    });
+
+    it("statRangeのデフォルト値が正しく適用される", () => {
+      const input = {
+        move: "じしん",
+        attacker: {
+          stat: { value: 205 },
+        },
+        defenderType: "physical",
+        options: {
+          statRange: {},
+        },
+      };
+
+      const result = calculateDamageMatrixInputSchema.parse(input);
+      expect(result.options?.statRange?.min).toBe(4);
+      expect(result.options?.statRange?.max).toBe(504);
+    });
+  });
+
+  describe("値の範囲検証", () => {
+    it("statが範囲外の場合はエラー", () => {
+      const input = {
+        move: "じしん",
+        attacker: {
+          stat: { value: 1000 },
+        },
+        defenderType: "physical",
+      };
+
+      const result = calculateDamageMatrixInputSchema.safeParse(input);
+      expect(result.success).toBe(false);
+    });
+
+    it("レベルが範囲外の場合はエラー", () => {
+      const input = {
+        move: "じしん",
+        attacker: {
+          level: 101,
+          stat: { value: 205 },
+        },
+        defenderType: "physical",
+      };
+
+      const result = calculateDamageMatrixInputSchema.safeParse(input);
+      expect(result.success).toBe(false);
+    });
+
+    it("statModifierが範囲外の場合はエラー", () => {
+      const input = {
+        move: "じしん",
+        attacker: {
+          stat: { value: 205 },
+          statModifier: 7,
+        },
+        defenderType: "physical",
+      };
+
+      const result = calculateDamageMatrixInputSchema.safeParse(input);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("defenderType検証", () => {
+    it("physical/special以外の値はエラー", () => {
+      const input = {
+        move: "じしん",
+        attacker: {
+          stat: { value: 205 },
+        },
+        defenderType: "invalid",
+      };
+
+      const result = calculateDamageMatrixInputSchema.safeParse(input);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("オプションフィールドの検証", () => {
+    it("全てのオプションフィールドが含まれていても有効", () => {
+      const input = {
+        move: "じしん",
+        attacker: {
+          pokemonName: "メタグロス",
+          level: 50,
+          stat: { value: 205 },
+          item: "こだわりハチマキ",
+          ability: "クリアボディ",
+          abilityActive: false,
+          statModifier: 0,
+        },
+        defenderType: "physical",
+        defender: {
+          pokemonName: "ボーマンダ",
+          level: 50,
+          item: "オボンのみ",
+          ability: "いかく",
+          abilityActive: false,
+          statModifier: 0,
+        },
+        options: {
+          weather: "はれ",
+          charge: false,
+          reflect: false,
+          lightScreen: false,
+          mudSport: false,
+          waterSport: false,
+          statRange: {
+            min: 10,
+            max: 400,
+          },
+        },
+      };
+
+      const result = calculateDamageMatrixInputSchema.safeParse(input);
+      expect(result.success).toBe(true);
+    });
+  });
+});

--- a/src/tools/calculateDamageMatrix/handlers/schemas/damageMatrixSchema.ts
+++ b/src/tools/calculateDamageMatrix/handlers/schemas/damageMatrixSchema.ts
@@ -1,0 +1,69 @@
+import { z } from "zod";
+
+const moveInputSchema = z.union([
+  z.string().describe("わざ名"),
+  z.object({
+    type: z.enum([
+      "ノーマル",
+      "ほのお",
+      "みず",
+      "でんき",
+      "くさ",
+      "こおり",
+      "かくとう",
+      "どく",
+      "じめん",
+      "ひこう",
+      "エスパー",
+      "むし",
+      "いわ",
+      "ゴースト",
+      "ドラゴン",
+      "あく",
+      "はがね",
+    ]).describe("わざのタイプ"),
+    power: z.number().min(1).max(250).describe("わざの威力"),
+  }).describe("タイプと威力を指定"),
+]);
+
+const attackerStatSchema = z.object({
+  value: z.number().min(1).max(999).describe("こうげきまたはとくこうの実数値"),
+});
+
+const statRangeSchema = z.object({
+  min: z.number().min(1).default(4).describe("最小防御ステータス"),
+  max: z.number().max(999).default(504).describe("最大防御ステータス"),
+});
+
+export const calculateDamageMatrixInputSchema = z.object({
+  move: moveInputSchema,
+  attacker: z.object({
+    pokemonName: z.string().optional().describe("ポケモン名"),
+    level: z.number().min(1).max(100).default(50).describe("レベル"),
+    stat: attackerStatSchema.describe("能力値"),
+    item: z.string().optional().describe("もちもの"),
+    ability: z.string().optional().describe("とくせい"),
+    abilityActive: z.boolean().optional().describe("条件付きとくせいが発動しているか"),
+    statModifier: z.number().min(-6).max(6).default(0).describe("能力ランク補正"),
+  }),
+  defenderType: z.enum(["physical", "special"]).describe("防御側のステータスタイプ"),
+  defender: z.object({
+    pokemonName: z.string().optional().describe("ポケモン名"),
+    level: z.number().min(1).max(100).default(50).describe("レベル"),
+    item: z.string().optional().describe("もちもの"),
+    ability: z.string().optional().describe("とくせい"),
+    abilityActive: z.boolean().optional().describe("条件付きとくせいが発動しているか"),
+    statModifier: z.number().min(-6).max(6).default(0).describe("能力ランク補正"),
+  }).optional(),
+  options: z.object({
+    weather: z.enum(["はれ", "あめ"]).optional().describe("てんき"),
+    charge: z.boolean().optional().describe("じゅうでん"),
+    reflect: z.boolean().optional().describe("リフレクター"),
+    lightScreen: z.boolean().optional().describe("ひかりのかべ"),
+    mudSport: z.boolean().optional().describe("どろあそび"),
+    waterSport: z.boolean().optional().describe("みずあそび"),
+    statRange: statRangeSchema.optional().describe("計算する防御ステータスの範囲"),
+  }).optional(),
+});
+
+export type CalculateDamageMatrixInput = z.infer<typeof calculateDamageMatrixInputSchema>;

--- a/src/tools/calculateDamageMatrix/handlers/schemas/index.ts
+++ b/src/tools/calculateDamageMatrix/handlers/schemas/index.ts
@@ -1,0 +1,4 @@
+export {
+  calculateDamageMatrixInputSchema,
+  type CalculateDamageMatrixInput,
+} from "./damageMatrixSchema";

--- a/src/tools/calculateDamageMatrix/types/damageMatrix.ts
+++ b/src/tools/calculateDamageMatrix/types/damageMatrix.ts
@@ -1,0 +1,32 @@
+import type { TypeName } from "@/types";
+
+export interface DamageMatrixEntry {
+  defenseStat: number;
+  damage: {
+    min: number;
+    max: number;
+    rolls: number[];
+  };
+}
+
+export interface DamageMatrixResult {
+  move: {
+    name?: string;
+    type: TypeName;
+    power: number;
+    category: "physical" | "special";
+  };
+  attacker: {
+    pokemonName?: string;
+    level: number;
+    stat: number;
+  };
+  damageMatrix: DamageMatrixEntry[];
+  modifiers?: {
+    typeEffectiveness?: number;
+    stab?: boolean;
+    weather?: string;
+    ability?: string;
+    item?: string;
+  };
+}

--- a/src/tools/shared/damageCalculation/calculateDamageCore.ts
+++ b/src/tools/shared/damageCalculation/calculateDamageCore.ts
@@ -1,0 +1,136 @@
+import type { AbilityName } from "@/data/abilities";
+import type { ItemName } from "@/data/items";
+import type { InternalDamageParams } from "@/tools/calculateDamage/types/damageCalculation";
+import { applyAbilityEffects } from "@/tools/calculateDamage/handlers/helpers/abilityEffects";
+import { calculateBaseDamage } from "@/tools/calculateDamage/handlers/helpers/calculateBaseDamage";
+import { getDamageRanges } from "@/tools/calculateDamage/handlers/helpers/damageRanges";
+import { calculateItemEffects } from "@/tools/calculateDamage/handlers/helpers/itemEffects";
+import { getStatModifierRatio } from "@/tools/calculateDamage/handlers/helpers/statModifier";
+import { getTypeEffectiveness } from "@/tools/calculateDamage/handlers/helpers/typeEffectiveness";
+
+/**
+ * ダメージ計算の主処理（共通化）
+ * 補正値、タイプ相性、とくせい効果を全て適用
+ */
+export const calculateDamageCore = (params: InternalDamageParams): number[] => {
+  const { move, attacker, defender, options } = params;
+
+  const attackerItemEffects = calculateItemEffects(
+    attacker.item as ItemName | undefined,
+    attacker.pokemonName,
+    move.type,
+    move.isPhysical,
+  );
+
+  const defenderItemEffects = calculateItemEffects(
+    defender.item as ItemName | undefined,
+    defender.pokemonName,
+    move.type,
+    move.isPhysical,
+  );
+
+  const attackRatio = getStatModifierRatio(attacker.attackModifier);
+  let attackStat = Math.floor(
+    (attacker.attack * attackRatio.numerator) / attackRatio.denominator,
+  );
+
+  if (move.isPhysical) {
+    attackStat = Math.floor(
+      (attackStat * attackerItemEffects.attackMultiplier.numerator) /
+        attackerItemEffects.attackMultiplier.denominator,
+    );
+  } else {
+    attackStat = Math.floor(
+      (attackStat * attackerItemEffects.specialAttackMultiplier.numerator) /
+        attackerItemEffects.specialAttackMultiplier.denominator,
+    );
+  }
+
+  const defenseRatio = getStatModifierRatio(defender.defenseModifier);
+  let defenseStat = Math.floor(
+    (defender.defense * defenseRatio.numerator) / defenseRatio.denominator,
+  );
+
+  if (move.isPhysical) {
+    defenseStat = Math.floor(
+      (defenseStat * defenderItemEffects.defenseMultiplier.numerator) /
+        defenderItemEffects.defenseMultiplier.denominator,
+    );
+  } else {
+    defenseStat = Math.floor(
+      (defenseStat * defenderItemEffects.specialDefenseMultiplier.numerator) /
+        defenderItemEffects.specialDefenseMultiplier.denominator,
+    );
+  }
+
+  // じばく・だいばくはつの処理: 防御を半分にする
+  if (
+    "name" in move &&
+    (move.name === "じばく" || move.name === "だいばくはつ")
+  ) {
+    defenseStat = Math.floor(defenseStat / 2);
+  }
+
+  let damage = calculateBaseDamage({
+    level: attacker.level,
+    power: move.power,
+    attack: attackStat,
+    defense: defenseStat,
+    isPhysical: move.isPhysical,
+  });
+
+  if (attacker.types?.some((type) => type === move.type)) {
+    damage = Math.floor(damage * 1.5);
+  }
+
+  const typeEffectiveness = getTypeEffectiveness(move.type, defender.types);
+  damage = Math.floor(damage * typeEffectiveness);
+
+  if (options.weather === "はれ") {
+    if (move.type === "ほのお") {
+      damage = Math.floor(damage * 1.5);
+    } else if (move.type === "みず") {
+      damage = Math.floor(damage * 0.5);
+    }
+  } else if (options.weather === "あめ") {
+    if (move.type === "みず") {
+      damage = Math.floor(damage * 1.5);
+    } else if (move.type === "ほのお") {
+      damage = Math.floor(damage * 0.5);
+    }
+  }
+
+  if (options.charge && move.type === "でんき") {
+    damage = Math.floor(damage * 2);
+  }
+
+  if (move.isPhysical && options.reflect) {
+    damage = Math.floor(damage * 0.5);
+  } else if (!move.isPhysical && options.lightScreen) {
+    damage = Math.floor(damage * 0.5);
+  }
+
+  if (options.mudSport && move.type === "でんき") {
+    damage = Math.floor(damage * 0.5);
+  }
+  if (options.waterSport && move.type === "ほのお") {
+    damage = Math.floor(damage * 0.5);
+  }
+
+  damage = applyAbilityEffects({
+    damage,
+    moveType: move.type,
+    attackerAbility: attacker.ability as AbilityName | undefined,
+    defenderAbility: defender.ability as AbilityName | undefined,
+    attackerAbilityActive: attacker.abilityActive,
+    defenderAbilityActive: defender.abilityActive,
+    typeEffectiveness,
+    isPhysical: move.isPhysical,
+  });
+
+  if (damage > 0) {
+    damage = Math.max(1, damage);
+  }
+
+  return getDamageRanges(damage);
+};

--- a/src/tools/shared/damageCalculation/index.ts
+++ b/src/tools/shared/damageCalculation/index.ts
@@ -1,0 +1,1 @@
+export { calculateDamageCore } from "./calculateDamageCore";

--- a/src/tools/shared/move/index.ts
+++ b/src/tools/shared/move/index.ts
@@ -1,0 +1,1 @@
+export { resolveMove, type ResolvedMove } from "./resolveMove";

--- a/src/tools/shared/move/resolveMove.ts
+++ b/src/tools/shared/move/resolveMove.ts
@@ -1,0 +1,60 @@
+import { MOVES } from "@/data/moves";
+import type { TypeName } from "@/types";
+
+export interface ResolvedMove {
+  name?: string;
+  type: TypeName;
+  power: number;
+  category: "physical" | "special";
+  isPhysical: boolean;
+}
+
+/**
+ * 第三世代のルールに基づいて物理技か特殊技かを判定
+ */
+const isPhysicalType = (type: TypeName): boolean => {
+  return [
+    "ノーマル",
+    "かくとう",
+    "ひこう",
+    "どく",
+    "じめん",
+    "いわ",
+    "むし",
+    "ゴースト",
+    "はがね",
+  ].includes(type);
+};
+
+/**
+ * わざ名または{type, power}オブジェクトからわざ情報を解決する
+ */
+export const resolveMove = (
+  moveInput: string | { type: TypeName; power: number }
+): ResolvedMove => {
+  if (typeof moveInput === "string") {
+    const moveData = MOVES.find((m) => m.name === moveInput);
+    if (!moveData) {
+      throw new Error(`技「${moveInput}」が見つかりません`);
+    }
+    const moveType = moveData.type as TypeName;
+    const isPhysical = isPhysicalType(moveType);
+    return {
+      name: moveInput,
+      type: moveType,
+      power: moveData.power,
+      category: isPhysical ? "physical" : "special",
+      isPhysical,
+    };
+  }
+
+  // オブジェクト形式の場合、第三世代のルールに基づいてカテゴリを判定
+  const isPhysical = isPhysicalType(moveInput.type);
+
+  return {
+    type: moveInput.type,
+    power: moveInput.power,
+    category: isPhysical ? "physical" : "special",
+    isPhysical,
+  };
+};

--- a/src/tools/shared/pokemon/index.ts
+++ b/src/tools/shared/pokemon/index.ts
@@ -1,0 +1,1 @@
+export { resolvePokemon, resolveItem, resolveAbility } from "./resolvePokemon";

--- a/src/tools/shared/pokemon/resolvePokemon.ts
+++ b/src/tools/shared/pokemon/resolvePokemon.ts
@@ -1,0 +1,47 @@
+import { ABILITIES, type Ability } from "@/data/abilities";
+import { ITEMS, type Item } from "@/data/items";
+import { POKEMONS, type Pokemon } from "@/data/pokemon";
+
+/**
+ * ポケモン名からポケモンデータを解決
+ */
+export const resolvePokemon = (
+  pokemonName?: string
+): Pokemon | undefined => {
+  if (!pokemonName) {
+    return undefined;
+  }
+  const pokemon = POKEMONS.find((p) => p.name === pokemonName);
+  if (!pokemon) {
+    throw new Error(`ポケモン「${pokemonName}」が見つかりません`);
+  }
+  return pokemon;
+};
+
+/**
+ * もちもの名からアイテムデータを解決
+ */
+export const resolveItem = (itemName?: string): Item | undefined => {
+  if (!itemName) {
+    return undefined;
+  }
+  const item = ITEMS.find((i) => i.name === itemName);
+  if (!item) {
+    throw new Error(`もちもの「${itemName}」が見つかりません`);
+  }
+  return item;
+};
+
+/**
+ * とくせい名からとくせいデータを解決
+ */
+export const resolveAbility = (abilityName?: string): Ability | undefined => {
+  if (!abilityName) {
+    return undefined;
+  }
+  const ability = ABILITIES.find((a) => a.name === abilityName);
+  if (!ability) {
+    throw new Error(`とくせい「${abilityName}」が見つかりません`);
+  }
+  return ability;
+};


### PR DESCRIPTION
## Summary
- Issue #24 に対応して、新しい`calculate_damage_matrix`ツールの基盤を実装しました
- 既存の`calculateDamage`から共通処理を抽出してリファクタリング
- 16段階の乱数を含むダメージ計算に対応

## 実装内容

### 1. 新しいツールの基本設計
- `calculate_damage_matrix`ツールの型定義とツール定義を作成
- Zodスキーマによる入力検証の実装
- 防御ステータス範囲（デフォルト: 4〜504）に対する一括計算に対応

### 2. 共通コードの抽出とリファクタリング
- **ダメージ計算のコア処理**: `calculateDamageCore`として`shared/damageCalculation`に移動
- **わざ情報の解決**: `resolveMove`ヘルパー関数を作成
- **ポケモン/アイテム/とくせいの解決**: `resolvePokemon`, `resolveItem`, `resolveAbility`を作成
- 既存の`calculateDamage`を共通関数を使うようにリファクタリング

## 次のステップ
- ハンドラーとダメージマトリックス計算ロジックの実装
- パフォーマンス最適化
- テストケースの追加

## Test plan
- [x] 型チェックが通ることを確認 (`npm run typecheck`)
- [ ] 既存のテストが通ることを確認
- [ ] 新しいツールのテストを追加（次のPRで実装予定）