### PR TITLE
fix: MCPレスポンスフォーマットを最新仕様に対応

### DIFF
--- a/src/tools/calculateDamage/handlers/handler.spec.ts
+++ b/src/tools/calculateDamage/handlers/handler.spec.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
+import { parseResponse } from "@/tools/test-helpers/parseResponse";
 import {
   isErrorOutput,
   isEvRangeDamageOutput,
   isNormalDamageOutput,
+  type StructuredOutput,
 } from "./formatters/structuredOutputFormatter";
 import { calculateDamageHandler } from "./handler";
 
@@ -34,9 +36,10 @@ describe("calculateDamageHandler", () => {
     };
 
     const result = await calculateDamageHandler(input);
-    expect(result.structuredContent).toBeDefined();
-    if (isNormalDamageOutput(result.structuredContent)) {
-      expect(result.structuredContent.damage).toBeDefined();
+    expect(result.content).toBeDefined();
+    const output = parseResponse<StructuredOutput>(result);
+    if (isNormalDamageOutput(output)) {
+      expect(output.damage).toBeDefined();
     }
   });
 
@@ -59,10 +62,11 @@ describe("calculateDamageHandler", () => {
     };
 
     const result = await calculateDamageHandler(input);
-    expect(result.structuredContent).toBeDefined();
-    if (isNormalDamageOutput(result.structuredContent)) {
-      expect(result.structuredContent.damage).toBeDefined();
-      expect(result.structuredContent.modifiers.typeEffectiveness).toBe(4);
+    expect(result.content).toBeDefined();
+    const output = parseResponse<StructuredOutput>(result);
+    if (isNormalDamageOutput(output)) {
+      expect(output.damage).toBeDefined();
+      expect(output.modifiers.typeEffectiveness).toBe(4);
     }
   });
 
@@ -85,9 +89,10 @@ describe("calculateDamageHandler", () => {
     };
 
     const result = await calculateDamageHandler(input);
-    expect(result.structuredContent).toBeDefined();
-    if (isNormalDamageOutput(result.structuredContent)) {
-      expect(result.structuredContent.modifiers.typeEffectiveness).toBe(4);
+    expect(result.content).toBeDefined();
+    const output = parseResponse<StructuredOutput>(result);
+    if (isNormalDamageOutput(output)) {
+      expect(output.modifiers.typeEffectiveness).toBe(4);
     }
   });
 
@@ -105,11 +110,10 @@ describe("calculateDamageHandler", () => {
     };
 
     const result = await calculateDamageHandler(input);
-    expect(result.structuredContent).toBeDefined();
-    if (isErrorOutput(result.structuredContent)) {
-      expect(result.structuredContent.error).toContain(
-        "わざ「存在しないわざ」が見つかりません",
-      );
+    expect(result.content).toBeDefined();
+    const output = parseResponse<StructuredOutput>(result);
+    if (isErrorOutput(output)) {
+      expect(output.error).toContain("わざ「存在しないわざ」が見つかりません");
     }
   });
 
@@ -141,11 +145,13 @@ describe("calculateDamageHandler", () => {
     });
 
     // 晴れ補正で1.5倍のダメージになることを確認
-    const normalDamage = isNormalDamageOutput(normalResult.structuredContent)
-      ? normalResult.structuredContent.damage.min
+    const normalOutput = parseResponse<StructuredOutput>(normalResult);
+    const sunOutput = parseResponse<StructuredOutput>(sunResult);
+    const normalDamage = isNormalDamageOutput(normalOutput)
+      ? normalOutput.damage.min
       : 0;
-    const sunDamage = isNormalDamageOutput(sunResult.structuredContent)
-      ? sunResult.structuredContent.damage.min
+    const sunDamage = isNormalDamageOutput(sunOutput)
+      ? sunOutput.damage.min
       : 0;
 
     // はれ補正は1.5倍だが、小数点以下切り捨てがあるので単純に比較
@@ -171,8 +177,9 @@ describe("calculateDamageHandler", () => {
     };
 
     const result = await calculateDamageHandler(input);
-    if (isNormalDamageOutput(result.structuredContent)) {
-      expect(result.structuredContent.damage.min).toBe(0);
+    const output = parseResponse<StructuredOutput>(result);
+    if (isNormalDamageOutput(output)) {
+      expect(output.damage.min).toBe(0);
     }
   });
 
@@ -195,8 +202,9 @@ describe("calculateDamageHandler", () => {
     };
 
     const result = await calculateDamageHandler(input);
-    if (isNormalDamageOutput(result.structuredContent)) {
-      expect(result.structuredContent.damage.min).toBe(0);
+    const output = parseResponse<StructuredOutput>(result);
+    if (isNormalDamageOutput(output)) {
+      expect(output.damage.min).toBe(0);
     }
   });
 
@@ -228,11 +236,13 @@ describe("calculateDamageHandler", () => {
     const normalResult = await calculateDamageHandler(normalInput);
     const powerResult = await calculateDamageHandler(powerInput);
 
-    const normalDamage = isNormalDamageOutput(normalResult.structuredContent)
-      ? normalResult.structuredContent.damage.min
+    const normalOutput = parseResponse<StructuredOutput>(normalResult);
+    const powerOutput = parseResponse<StructuredOutput>(powerResult);
+    const normalDamage = isNormalDamageOutput(normalOutput)
+      ? normalOutput.damage.min
       : 0;
-    const powerDamage = isNormalDamageOutput(powerResult.structuredContent)
-      ? powerResult.structuredContent.damage.min
+    const powerDamage = isNormalDamageOutput(powerOutput)
+      ? powerOutput.damage.min
       : 0;
 
     // ちからもちで2倍のダメージ
@@ -266,15 +276,12 @@ describe("calculateDamageHandler", () => {
       };
 
       const result = await calculateDamageHandler(input);
-      if (isEvRangeDamageOutput(result.structuredContent)) {
-        expect(result.structuredContent.evRanges).toBeDefined();
-        expect(result.structuredContent.evRanges.length).toBeGreaterThan(0);
-        expect(result.structuredContent.evRanges[0].ev).toBe(0);
-        expect(
-          result.structuredContent.evRanges[
-            result.structuredContent.evRanges.length - 1
-          ].ev,
-        ).toBe(252);
+      const output = parseResponse<StructuredOutput>(result);
+      if (isEvRangeDamageOutput(output)) {
+        expect(output.evRanges).toBeDefined();
+        expect(output.evRanges.length).toBeGreaterThan(0);
+        expect(output.evRanges[0].ev).toBe(0);
+        expect(output.evRanges[output.evRanges.length - 1].ev).toBe(252);
       }
     });
 
@@ -304,15 +311,12 @@ describe("calculateDamageHandler", () => {
       };
 
       const result = await calculateDamageHandler(input);
-      if (isEvRangeDamageOutput(result.structuredContent)) {
-        expect(result.structuredContent.evRanges).toBeDefined();
-        expect(result.structuredContent.evRanges.length).toBeGreaterThan(0);
-        expect(result.structuredContent.evRanges[0].ev).toBe(0);
-        expect(
-          result.structuredContent.evRanges[
-            result.structuredContent.evRanges.length - 1
-          ].ev,
-        ).toBe(252);
+      const output = parseResponse<StructuredOutput>(result);
+      if (isEvRangeDamageOutput(output)) {
+        expect(output.evRanges).toBeDefined();
+        expect(output.evRanges.length).toBeGreaterThan(0);
+        expect(output.evRanges[0].ev).toBe(0);
+        expect(output.evRanges[output.evRanges.length - 1].ev).toBe(252);
       }
     });
 
@@ -341,9 +345,10 @@ describe("calculateDamageHandler", () => {
       };
 
       const result = await calculateDamageHandler(input);
-      if (isErrorOutput(result.structuredContent)) {
-        expect(result.structuredContent.error).toBeDefined();
-        expect(result.structuredContent.error).toContain(
+      const output = parseResponse<StructuredOutput>(result);
+      if (isErrorOutput(output)) {
+        expect(output.error).toBeDefined();
+        expect(output.error).toContain(
           "攻撃側と防御側の両方でcalculateAllEvsを使うことはできません",
         );
       }
@@ -375,17 +380,16 @@ describe("calculateDamageHandler", () => {
       };
 
       const result = await calculateDamageHandler(input);
-      if (isEvRangeDamageOutput(result.structuredContent)) {
-        expect(result.structuredContent.evRanges).toBeDefined();
+      const output = parseResponse<StructuredOutput>(result);
+      if (isEvRangeDamageOutput(output)) {
+        expect(output.evRanges).toBeDefined();
 
         // 中間のEV値（124）も含まれることを確認
-        const ev124Entry = result.structuredContent.evRanges.find(
-          (e) => e.ev === 124,
-        );
+        const ev124Entry = output.evRanges.find((e) => e.ev === 124);
         expect(ev124Entry).toBeDefined();
 
         // タイプ相性が正しく設定されることを確認
-        expect(result.structuredContent.modifiers.typeEffectiveness).toBe(2);
+        expect(output.modifiers.typeEffectiveness).toBe(2);
       }
     });
 
@@ -416,10 +420,11 @@ describe("calculateDamageHandler", () => {
 
       const result = await calculateDamageHandler(input);
 
-      // C145（性格補正なし）の場合、タイプ一致で72〜85付近のダメージ
-      if (isNormalDamageOutput(result.structuredContent)) {
-        expect(result.structuredContent.damage.min).toBeGreaterThanOrEqual(72);
-        expect(result.structuredContent.damage.max).toBeLessThanOrEqual(85);
+      // C145（性格裍正なし）の場合、タイプ一致で72〜85付近のダメージ
+      const output = parseResponse<StructuredOutput>(result);
+      if (isNormalDamageOutput(output)) {
+        expect(output.damage.min).toBeGreaterThanOrEqual(72);
+        expect(output.damage.max).toBeLessThanOrEqual(85);
       }
     });
   });
@@ -455,15 +460,13 @@ describe("calculateDamageHandler", () => {
         options: {},
       });
 
-      const normalMinDamage = isNormalDamageOutput(
-        normalResult.structuredContent,
-      )
-        ? normalResult.structuredContent.damage.min
+      const normalOutput = parseResponse<StructuredOutput>(normalResult);
+      const activeOutput = parseResponse<StructuredOutput>(activeResult);
+      const normalMinDamage = isNormalDamageOutput(normalOutput)
+        ? normalOutput.damage.min
         : 0;
-      const activeMinDamage = isNormalDamageOutput(
-        activeResult.structuredContent,
-      )
-        ? activeResult.structuredContent.damage.min
+      const activeMinDamage = isNormalDamageOutput(activeOutput)
+        ? activeOutput.damage.min
         : 0;
 
       // もうか発動時は1.5倍のダメージ
@@ -500,15 +503,13 @@ describe("calculateDamageHandler", () => {
         options: {},
       });
 
-      const normalMinDamage = isNormalDamageOutput(
-        normalResult.structuredContent,
-      )
-        ? normalResult.structuredContent.damage.min
+      const normalOutput = parseResponse<StructuredOutput>(normalResult);
+      const activeOutput = parseResponse<StructuredOutput>(activeResult);
+      const normalMinDamage = isNormalDamageOutput(normalOutput)
+        ? normalOutput.damage.min
         : 0;
-      const activeMinDamage = isNormalDamageOutput(
-        activeResult.structuredContent,
-      )
-        ? activeResult.structuredContent.damage.min
+      const activeMinDamage = isNormalDamageOutput(activeOutput)
+        ? activeOutput.damage.min
         : 0;
 
       // ふしぎなうろこ発動時は2/3のダメージ

--- a/src/tools/calculateDamage/handlers/handlerErrorTest.spec.ts
+++ b/src/tools/calculateDamage/handlers/handlerErrorTest.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { parseResponse } from "@/tools/test-helpers/parseResponse";
 import { calculateDamageHandler } from "./handler";
 
 describe("calculateDamageHandler エラーハンドリング", () => {
@@ -18,9 +19,8 @@ describe("calculateDamageHandler エラーハンドリング", () => {
     };
 
     const result = await calculateDamageHandler(input);
-    expect(
-      "error" in result.structuredContent && result.structuredContent.error,
-    ).toContain(
+    const output = parseResponse<{ error: string }>(result);
+    expect("error" in output && output.error).toContain(
       '「move」は文字列（わざ名）または { type: "タイプ名", power: 威力 } の形式で指定してください',
     );
   });
@@ -28,11 +28,10 @@ describe("calculateDamageHandler エラーハンドリング", () => {
   it("不正なJSONフォーマットの場合でも適切に処理する", async () => {
     const input = undefined;
     const result = await calculateDamageHandler(input);
-    expect(
-      "error" in result.structuredContent && result.structuredContent.error,
-    ).toBeTruthy();
-    if ("error" in result.structuredContent) {
-      expect(result.structuredContent.error).toContain("入力エラー");
+    const output = parseResponse<{ error: string }>(result);
+    expect("error" in output && output.error).toBeTruthy();
+    if ("error" in output) {
+      expect(output.error).toContain("入力エラー");
     }
   });
 
@@ -52,9 +51,10 @@ describe("calculateDamageHandler エラーハンドリング", () => {
     };
 
     const result = await calculateDamageHandler(input);
-    expect(
-      "error" in result.structuredContent && result.structuredContent.error,
-    ).toContain("ポケモン「存在しないポケモン」が見つかりません");
+    const output = parseResponse<{ error: string }>(result);
+    expect("error" in output && output.error).toContain(
+      "ポケモン「存在しないポケモン」が見つかりません",
+    );
   });
 
   it("存在しないわざ名の場合、具体的なエラーメッセージを返す", async () => {
@@ -73,9 +73,10 @@ describe("calculateDamageHandler エラーハンドリング", () => {
     };
 
     const result = await calculateDamageHandler(input);
-    expect(
-      "error" in result.structuredContent && result.structuredContent.error,
-    ).toContain("わざ「存在しないわざ」が見つかりません");
+    const output = parseResponse<{ error: string }>(result);
+    expect("error" in output && output.error).toContain(
+      "わざ「存在しないわざ」が見つかりません",
+    );
   });
 
   it("レベルが範囲外の場合、分かりやすいエラーメッセージを返す", async () => {
@@ -94,8 +95,9 @@ describe("calculateDamageHandler エラーハンドリング", () => {
     };
 
     const result = await calculateDamageHandler(input);
-    expect(
-      "error" in result.structuredContent && result.structuredContent.error,
-    ).toContain("「attacker.level」は1以上である必要があります");
+    const output = parseResponse<{ error: string }>(result);
+    expect("error" in output && output.error).toContain(
+      "「attacker.level」は1以上である必要があります",
+    );
   });
 });

--- a/src/tools/calculateDamage/handlers/helpers/calculateEvDamages/calculateEvDamages.spec.ts
+++ b/src/tools/calculateDamage/handlers/helpers/calculateEvDamages/calculateEvDamages.spec.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { isNormalDamageOutput } from "@/tools/calculateDamage/handlers/formatters/structuredOutputFormatter";
+import {
+  isNormalDamageOutput,
+  type StructuredOutput,
+} from "@/tools/calculateDamage/handlers/formatters/structuredOutputFormatter";
 import { calculateDamageHandler } from "@/tools/calculateDamage/handlers/handler";
+import { parseResponse } from "@/tools/test-helpers/parseResponse";
 
 describe("じばく・だいばくはつの防御半減", () => {
   it("じばくで防御が半減される", async () => {
@@ -23,8 +27,9 @@ describe("じばく・だいばくはつの防御半減", () => {
     };
 
     const normalResult = await calculateDamageHandler(normalInput);
-    const normalMinDamage = isNormalDamageOutput(normalResult.structuredContent)
-      ? normalResult.structuredContent.damage.min
+    const normalOutput = parseResponse<StructuredOutput>(normalResult);
+    const normalMinDamage = isNormalDamageOutput(normalOutput)
+      ? normalOutput.damage.min
       : 0;
 
     // じばくでのダメージ計算（防御半減）
@@ -46,10 +51,10 @@ describe("じばく・だいばくはつの防御半減", () => {
     };
 
     const selfDestructResult = await calculateDamageHandler(selfDestructInput);
-    const selfDestructMinDamage = isNormalDamageOutput(
-      selfDestructResult.structuredContent,
-    )
-      ? selfDestructResult.structuredContent.damage.min
+    const selfDestructOutput =
+      parseResponse<StructuredOutput>(selfDestructResult);
+    const selfDestructMinDamage = isNormalDamageOutput(selfDestructOutput)
+      ? selfDestructOutput.damage.min
       : 0;
 
     // じばくは威力200で防御半減なので、とっしん（威力90）の2倍以上のダメージになるはず
@@ -75,10 +80,9 @@ describe("じばく・だいばくはつの防御半減", () => {
     };
 
     const explosionResult = await calculateDamageHandler(explosionInput);
-    const explosionMinDamage = isNormalDamageOutput(
-      explosionResult.structuredContent,
-    )
-      ? explosionResult.structuredContent.damage.min
+    const explosionOutput = parseResponse<StructuredOutput>(explosionResult);
+    const explosionMinDamage = isNormalDamageOutput(explosionOutput)
+      ? explosionOutput.damage.min
       : 0;
 
     // だいばくはつは威力250で防御半減なので大きなダメージになるはず
@@ -104,10 +108,9 @@ describe("じばく・だいばくはつの防御半減", () => {
     };
 
     const hyperBeamResult = await calculateDamageHandler(hyperBeamInput);
-    const hyperBeamMaxDamage = isNormalDamageOutput(
-      hyperBeamResult.structuredContent,
-    )
-      ? hyperBeamResult.structuredContent.damage.max
+    const hyperBeamOutput = parseResponse<StructuredOutput>(hyperBeamResult);
+    const hyperBeamMaxDamage = isNormalDamageOutput(hyperBeamOutput)
+      ? hyperBeamOutput.damage.max
       : 0;
 
     // 防御が高いため、ダメージは少なめになるはず

--- a/src/tools/calculateDamage/handlers/helpers/formatError.spec.ts
+++ b/src/tools/calculateDamage/handlers/helpers/formatError.spec.ts
@@ -7,8 +7,12 @@ describe("formatError", () => {
     const error = new Error("テストエラー");
     const result = formatError(error);
 
-    expect(result.structuredContent.error).toBe("テストエラー");
-    expect(result.structuredContent.move).toEqual({
+    expect(result.isError).toBe(true);
+    expect(result.content).toBeDefined();
+    expect(result.content[0].type).toBe("text");
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.error).toBe("テストエラー");
+    expect(parsed.move).toEqual({
       type: "unknown",
       power: 0,
       category: "unknown",
@@ -19,7 +23,9 @@ describe("formatError", () => {
     const error = "文字列エラー";
     const result = formatError(error);
 
-    expect(result.structuredContent.error).toBe("不明なエラーが発生しました");
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.error).toBe("不明なエラーが発生しました");
   });
 
   it("ZodErrorの場合は分かりやすいメッセージに変換する", () => {
@@ -34,9 +40,9 @@ describe("formatError", () => {
     ]);
 
     const result = formatError(zodError);
-    expect(result.structuredContent.error).toBe(
-      "入力エラー:\n「move」フィールドが必須です",
-    );
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.error).toBe("入力エラー:\n「move」フィールドが必須です");
   });
 
   it("複数のZodErrorを適切にフォーマットする", () => {
@@ -58,7 +64,9 @@ describe("formatError", () => {
     ]);
 
     const result = formatError(zodError);
-    expect(result.structuredContent.error).toBe(
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.error).toBe(
       "入力エラー:\n「attacker」フィールドが必須です\n「defender.level」はnumber型である必要があります（現在: string型）",
     );
   });
@@ -77,7 +85,9 @@ describe("formatError", () => {
     ]);
 
     const result = formatError(zodError);
-    expect(result.structuredContent.error).toBe(
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.error).toBe(
       "入力エラー:\n「attacker.level」は1以上である必要があります",
     );
   });

--- a/src/tools/calculateDamage/handlers/helpers/formatError.ts
+++ b/src/tools/calculateDamage/handlers/helpers/formatError.ts
@@ -55,10 +55,8 @@ const formatZodError = (error: ZodError): string => {
 export const formatError = (
   error: unknown,
 ): {
-  structuredContent: {
-    error: string;
-    move: { type: string; power: number; category: string };
-  };
+  isError: true;
+  content: Array<{ type: "text"; text: string }>;
 } => {
   const message = (() => {
     if (error instanceof ZodError) {
@@ -70,15 +68,23 @@ export const formatError = (
     return "不明なエラーが発生しました";
   })();
 
-  return {
-    structuredContent: {
-      error: message,
-      // エラー時でも最小限のmove情報を含める（スキーマ準拠のため）
-      move: {
-        type: "unknown",
-        power: 0,
-        category: "unknown",
-      },
+  const errorOutput = {
+    error: message,
+    // エラー時でも最小限のmove情報を含める（スキーマ準拠のため）
+    move: {
+      type: "unknown",
+      power: 0,
+      category: "unknown",
     },
+  };
+
+  return {
+    isError: true,
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify(errorOutput, null, 2),
+      },
+    ],
   };
 };

--- a/src/tools/calculateStatus/handlers/handler.spec.ts
+++ b/src/tools/calculateStatus/handlers/handler.spec.ts
@@ -1,4 +1,9 @@
 import { describe, expect, it } from "vitest";
+import { parseResponse } from "@/tools/test-helpers/parseResponse";
+import type {
+  CalculateStatusErrorOutput,
+  CalculateStatusOutput,
+} from "../types";
 import { calculateStatusHandler } from "./handler";
 
 describe("calculate-status tool", () => {
@@ -14,10 +19,11 @@ describe("calculate-status tool", () => {
     const result = await calculateStatusHandler(input);
 
     expect(result).toBeDefined();
-    expect(result.structuredContent).toBeDefined();
-    expect(result.structuredContent?.pokemonName).toBe("フシギダネ");
-    expect(result.structuredContent?.stats?.hp).toBe(112);
-    expect(result.structuredContent?.stats?.atk).toBe(61);
+    expect(result.content).toBeDefined();
+    const output = parseResponse<CalculateStatusOutput>(result);
+    expect(output.pokemonName).toBe("フシギダネ");
+    expect(output.stats.hp).toBe(112);
+    expect(output.stats.atk).toBe(61);
   });
 
   it("存在しないポケモン名でエラーになること", async () => {
@@ -30,11 +36,10 @@ describe("calculate-status tool", () => {
     };
 
     const result = await calculateStatusHandler(input);
-    expect("error" in result.structuredContent).toBe(true);
-    if ("error" in result.structuredContent) {
-      expect(result.structuredContent.error).toContain(
-        "ポケモン「ミュウツーX」が見つかりません",
-      );
+    const output = parseResponse<CalculateStatusErrorOutput>(result);
+    expect("error" in output).toBe(true);
+    if ("error" in output) {
+      expect(output.error).toContain("ポケモン「ミュウツーX」が見つかりません");
     }
   });
 
@@ -48,11 +53,10 @@ describe("calculate-status tool", () => {
     };
 
     const result = await calculateStatusHandler(input);
-    expect("error" in result.structuredContent).toBe(true);
-    if ("error" in result.structuredContent) {
-      expect(result.structuredContent.error).toContain(
-        "せいかく「つよき」が見つかりません",
-      );
+    const output = parseResponse<CalculateStatusErrorOutput>(result);
+    expect("error" in output).toBe(true);
+    if ("error" in output) {
+      expect(output.error).toContain("せいかく「つよき」が見つかりません");
     }
   });
 
@@ -66,9 +70,10 @@ describe("calculate-status tool", () => {
     };
 
     const result = await calculateStatusHandler(input);
-    expect("error" in result.structuredContent).toBe(true);
-    if ("error" in result.structuredContent) {
-      expect(result.structuredContent.error).toContain(
+    const output = parseResponse<CalculateStatusErrorOutput>(result);
+    expect("error" in output).toBe(true);
+    if ("error" in output) {
+      expect(output.error).toContain(
         "努力値の合計は510以下でなければなりません",
       );
     }
@@ -85,7 +90,8 @@ describe("calculate-status tool", () => {
 
     const result = await calculateStatusHandler(input);
 
-    expect(result.structuredContent?.pokemonName).toBe("ヌケニン");
-    expect(result.structuredContent?.stats?.hp).toBe(1);
+    const output = parseResponse<CalculateStatusOutput>(result);
+    expect(output.pokemonName).toBe("ヌケニン");
+    expect(output.stats.hp).toBe(1);
   });
 });

--- a/src/tools/calculateStatus/handlers/handler.ts
+++ b/src/tools/calculateStatus/handlers/handler.ts
@@ -5,7 +5,17 @@ import { natureModifier } from "@/utils/natureModifier";
 import { formatError } from "./helpers";
 import { calculateStatusInputSchema } from "./schemas/statusSchema";
 
-export const calculateStatusHandler = async (args: unknown) => {
+export const calculateStatusHandler = async (
+  args: unknown,
+): Promise<
+  | {
+      content: Array<{ type: "text"; text: string }>;
+    }
+  | {
+      isError: true;
+      content: Array<{ type: "text"; text: string }>;
+    }
+> => {
   try {
     const parsedData = calculateStatusInputSchema.parse(args);
 
@@ -64,11 +74,18 @@ export const calculateStatusHandler = async (args: unknown) => {
 
     const stats: StatsObj = { hp, atk, def, spa, spd, spe };
 
+    const structuredOutput = {
+      pokemonName: pokemon.name,
+      stats,
+    };
+
     return {
-      structuredContent: {
-        pokemonName: pokemon.name,
-        stats,
-      },
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(structuredOutput, null, 2),
+        },
+      ],
     };
   } catch (error) {
     return formatError(error);

--- a/src/tools/calculateStatus/handlers/handlerErrorTest.spec.ts
+++ b/src/tools/calculateStatus/handlers/handlerErrorTest.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { parseResponse } from "@/tools/test-helpers/parseResponse";
 import { calculateStatusHandler } from "./handler";
 
 describe("calculateStatusHandler エラーハンドリング", () => {
@@ -12,11 +13,10 @@ describe("calculateStatusHandler エラーハンドリング", () => {
     };
 
     const result = await calculateStatusHandler(input);
-    expect("error" in result.structuredContent).toBe(true);
-    if ("error" in result.structuredContent) {
-      expect(result.structuredContent.error).toContain(
-        "「pokemonName」フィールドが必須です",
-      );
+    const output = parseResponse<{ error: string }>(result);
+    expect("error" in output).toBe(true);
+    if ("error" in output) {
+      expect(output.error).toContain("「pokemonName」フィールドが必須です");
     }
   });
 
@@ -30,9 +30,10 @@ describe("calculateStatusHandler エラーハンドリング", () => {
     };
 
     const result = await calculateStatusHandler(input);
-    expect("error" in result.structuredContent).toBe(true);
-    if ("error" in result.structuredContent) {
-      expect(result.structuredContent.error).toContain(
+    const output = parseResponse<{ error: string }>(result);
+    expect("error" in output).toBe(true);
+    if ("error" in output) {
+      expect(output.error).toContain(
         "ポケモン「存在しないポケモン」が見つかりません",
       );
     }
@@ -48,9 +49,10 @@ describe("calculateStatusHandler エラーハンドリング", () => {
     };
 
     const result = await calculateStatusHandler(input);
-    expect("error" in result.structuredContent).toBe(true);
-    if ("error" in result.structuredContent) {
-      expect(result.structuredContent.error).toContain(
+    const output = parseResponse<{ error: string }>(result);
+    expect("error" in output).toBe(true);
+    if ("error" in output) {
+      expect(output.error).toContain(
         "せいかく「無効なせいかく」が見つかりません",
       );
     }
@@ -66,9 +68,10 @@ describe("calculateStatusHandler エラーハンドリング", () => {
     };
 
     const result = await calculateStatusHandler(input);
-    expect("error" in result.structuredContent).toBe(true);
-    if ("error" in result.structuredContent) {
-      expect(result.structuredContent.error).toContain(
+    const output = parseResponse<{ error: string }>(result);
+    expect("error" in output).toBe(true);
+    if ("error" in output) {
+      expect(output.error).toContain(
         "「evs.spa」は252以下である必要があります",
       );
     }

--- a/src/tools/calculateStatus/handlers/helpers/formatError.ts
+++ b/src/tools/calculateStatus/handlers/helpers/formatError.ts
@@ -37,18 +37,8 @@ const formatZodError = (error: ZodError): string => {
 export const formatError = (
   error: unknown,
 ): {
-  structuredContent: {
-    error: string;
-    pokemonName: string;
-    stats: {
-      hp: number;
-      atk: number;
-      def: number;
-      spa: number;
-      spd: number;
-      spe: number;
-    };
-  };
+  isError: true;
+  content: Array<{ type: "text"; text: string }>;
 } => {
   const message = (() => {
     if (error instanceof ZodError) {
@@ -60,19 +50,27 @@ export const formatError = (
     return "不明なエラーが発生しました";
   })();
 
-  return {
-    structuredContent: {
-      error: message,
-      // エラー時でも最小限の情報を含める（スキーマ準拠のため）
-      pokemonName: "unknown",
-      stats: {
-        hp: 0,
-        atk: 0,
-        def: 0,
-        spa: 0,
-        spd: 0,
-        spe: 0,
-      },
+  const errorOutput = {
+    error: message,
+    // エラー時でも最小限の情報を含める（スキーマ準拠のため）
+    pokemonName: "unknown",
+    stats: {
+      hp: 0,
+      atk: 0,
+      def: 0,
+      spa: 0,
+      spd: 0,
+      spe: 0,
     },
+  };
+
+  return {
+    isError: true,
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify(errorOutput, null, 2),
+      },
+    ],
   };
 };

--- a/src/tools/calculateStatus/types/index.ts
+++ b/src/tools/calculateStatus/types/index.ts
@@ -1,0 +1,12 @@
+import type { StatsObj } from "@/types";
+
+export interface CalculateStatusOutput {
+  pokemonName: string;
+  stats: StatsObj;
+}
+
+export interface CalculateStatusErrorOutput {
+  error: string;
+  pokemonName: string;
+  stats: StatsObj;
+}

--- a/src/tools/test-helpers/parseResponse.ts
+++ b/src/tools/test-helpers/parseResponse.ts
@@ -1,0 +1,31 @@
+/**
+ * MCPレスポンスから構造化されたコンテンツを抽出する
+ */
+export const parseResponse = <T = unknown>(
+  response:
+    | { content: Array<{ type: string; text: string }> }
+    | { isError: true; content: Array<{ type: string; text: string }> },
+): T => {
+  const textContent = response.content[0];
+  if (!textContent || textContent.type !== "text") {
+    throw new Error("Unexpected response format");
+  }
+  return JSON.parse(textContent.text) as T;
+};
+
+/**
+ * レスポンスがエラーかどうかを判定する
+ */
+export const isErrorResponse = (
+  response: unknown,
+): response is {
+  isError: true;
+  content: Array<{ type: string; text: string }>;
+} => {
+  return (
+    typeof response === "object" &&
+    response !== null &&
+    "isError" in response &&
+    response.isError === true
+  );
+};


### PR DESCRIPTION
## 概要

MCPクライアントが期待するレスポンスフォーマットに合わせて修正しました。

## 変更内容

- `structuredContent`から`content`配列形式に変更
- `content`配列に`{ type: "text", text: string }`形式のオブジェクトを含める
- エラー時は`isError: true`を含める
- テスト用の`parseResponse`ヘルパー関数を追加
- すべてのテストを新しいレスポンス形式に対応

## 背景

`ClaudeAiToolResultRequest.content.0.text.text: Field required`というエラーが発生していたため、最新のMCP仕様（v1.13.1）に準拠したレスポンス形式に更新しました。

### 以前のレスポンス形式
```typescript
{
  structuredContent: {
    // 構造化データ
  }
}
```

### 新しいレスポンス形式
```typescript
{
  content: [
    {
      type: "text",
      text: JSON.stringify(structuredData, null, 2)
    }
  ]
}
```

エラー時：
```typescript
{
  isError: true,
  content: [
    {
      type: "text",
      text: JSON.stringify(errorData, null, 2)
    }
  ]
}
```

## テスト計画

- [x] 型チェック（`npm run typecheck`）
- [x] リント（`npm run lint`）
- [x] ユニットテスト（`npm run test`）
- [x] 全チェック（`npm run check`）
- [ ] MCPクライアントでの動作確認

## 関連issue/PR

- 関連issue: #26（エラーメッセージの改善）