### PR TITLE
refactor: damageSchemaから不要な型アサーションを削除

### DIFF
--- a/src/tools/calculateDamage/handlers/schemas/damageSchema/damageSchema.ts
+++ b/src/tools/calculateDamage/handlers/schemas/damageSchema/damageSchema.ts
@@ -29,12 +29,11 @@ const moveInputSchema = z.union([
       if (!move) {
         throw new Error(`わざ「${moveName}」が見つかりません`);
       }
-      const moveType = move.type as TypeName;
       return {
         name: moveName,
-        type: moveType,
+        type: move.type,
         power: move.power,
-        isPhysical: isPhysicalType(moveType),
+        isPhysical: isPhysicalType(move.type),
       };
     }),
   // タイプと威力を直接指定


### PR DESCRIPTION
## 概要
`damageSchema.ts`から不要な型アサーション（`as TypeName`）を削除しました。

## 変更内容
- `move.type`は既に`TypeName`として型付けされているため、型アサーションは不要でした
- 一時変数`moveType`も削除し、直接`move.type`を使用するようにしました

## 理由
型アサーションは型安全性を損なう可能性があるため、可能な限り使用を避けるべきです。今回のケースでは、`MOVES`配列の各要素の`type`プロパティは既に`TypeName`型として定義されているため、アサーションは不要でした。

## テスト
- `npm run check`で型チェック、リント、テストがすべて通ることを確認済み