### PR TITLE
refactor: 重複したエラーハンドリングコードを共通化

### DIFF
--- a/src/tools/calculateDamage/handlers/handler.ts
+++ b/src/tools/calculateDamage/handlers/handler.ts
@@ -22,15 +22,31 @@ import {
 } from "./schemas/damageSchema";
 
 /**
+ * 計算結果をMCPレスポンス形式に変換する共通関数
+ */
+const createCalculationResponse = (
+  structuredOutput: unknown,
+): {
+  content: Array<{ type: "text"; text: string }>;
+} => {
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify(structuredOutput, null, 2),
+      },
+    ],
+  };
+};
+
+/**
  * 防御側のステータスを固定し、攻撃側のEV別ダメージを計算
  */
 const handleAttackerEvCalculation = (
   input: CalculateDamageInput,
   attackStatArray: number[],
   fixedDefenseStat: number,
-): {
-  content: Array<{ type: "text"; text: string }>;
-} => {
+) => {
   const context = prepareCalculationContext(input);
   const evResults = calculateAttackerEvDamages(
     input,
@@ -45,14 +61,7 @@ const handleAttackerEvCalculation = (
     isAttackerEv: true,
   });
 
-  return {
-    content: [
-      {
-        type: "text",
-        text: JSON.stringify(structuredOutput, null, 2),
-      },
-    ],
-  };
+  return createCalculationResponse(structuredOutput);
 };
 
 /**
@@ -62,9 +71,7 @@ const handleDefenderEvCalculation = (
   input: CalculateDamageInput,
   fixedAttackStat: number,
   defenseStatArray: number[],
-): {
-  content: Array<{ type: "text"; text: string }>;
-} => {
+) => {
   const context = prepareCalculationContext(input);
   const evResults = calculateDefenderEvDamages(
     input,
@@ -79,14 +86,7 @@ const handleDefenderEvCalculation = (
     isAttackerEv: false,
   });
 
-  return {
-    content: [
-      {
-        type: "text",
-        text: JSON.stringify(structuredOutput, null, 2),
-      },
-    ],
-  };
+  return createCalculationResponse(structuredOutput);
 };
 
 /**
@@ -96,9 +96,7 @@ const handleNormalCalculation = (
   input: CalculateDamageInput,
   attackStat: number,
   defenseStat: number,
-): {
-  content: Array<{ type: "text"; text: string }>;
-} => {
+) => {
   const context = prepareCalculationContext(input);
   const damages = calculateNormalDamage(input, attackStat, defenseStat);
 
@@ -109,14 +107,7 @@ const handleNormalCalculation = (
     defenseStat,
   });
 
-  return {
-    content: [
-      {
-        type: "text",
-        text: JSON.stringify(structuredOutput, null, 2),
-      },
-    ],
-  };
+  return createCalculationResponse(structuredOutput);
 };
 
 /**
@@ -125,9 +116,7 @@ const handleNormalCalculation = (
 const handleEvCalculation = (
   input: CalculateDamageInput,
   stats: ReturnType<typeof getCalculatedStats>,
-): {
-  content: Array<{ type: "text"; text: string }>;
-} => {
+) => {
   const { attackStat, defenseStat } = stats;
 
   if (isAttackerEvArray(attackStat)) {

--- a/src/tools/calculateDamage/handlers/helpers/formatError.ts
+++ b/src/tools/calculateDamage/handlers/helpers/formatError.ts
@@ -1,90 +1,15 @@
-import { ZodError } from "zod";
+import { formatError as baseFormatError } from "@/utils/error";
 
-/**
- * ZodErrorを分かりやすいメッセージに変換する
- */
-const formatZodError = (error: ZodError): string => {
-  const issues = error.issues.map((issue) => {
-    const path = issue.path.join(".");
-
-    switch (issue.code) {
-      case "invalid_type":
-        if (issue.received === "undefined") {
-          return `「${path}」フィールドが必須です`;
-        }
-        return `「${path}」は${issue.expected}型である必要があります（現在: ${issue.received}型）`;
-
-      case "invalid_union": {
-        // Unionタイプの検証失敗時は、最初の失敗理由から必須フィールドエラーを判定
-        const unionErrors = error.errors.filter(
-          (e) => e.path.join(".") === path,
-        );
-        if (
-          unionErrors.some(
-            (e) => e.code === "invalid_type" && e.received === "undefined",
-          )
-        ) {
-          return `「${path}」フィールドが必須です`;
-        }
-
-        // moveフィールドの場合は特別なメッセージを返す
-        if (path === "move") {
-          return '「move」は文字列（わざ名）または { type: "タイプ名", power: 威力 } の形式で指定してください';
-        }
-
-        return `「${path}」の形式が正しくありません`;
-      }
-
-      case "too_small":
-        return `「${path}」は${issue.minimum}以上である必要があります`;
-
-      case "too_big":
-        return `「${path}」は${issue.maximum}以下である必要があります`;
-
-      case "invalid_enum_value":
-        return `「${path}」は次のいずれかの値である必要があります: ${issue.options.join(", ")}`;
-
-      default:
-        return `「${path}」: ${issue.message}`;
-    }
-  });
-
-  return `入力エラー:\n${issues.join("\n")}`;
+// calculateDamage用のデフォルトエラー出力
+const DEFAULT_ERROR_OUTPUT = {
+  // エラー時でも最小限のmove情報を含める（スキーマ準拠のため）
+  move: {
+    type: "unknown",
+    power: 0,
+    category: "unknown",
+  },
 };
 
-export const formatError = (
-  error: unknown,
-): {
-  isError: true;
-  content: Array<{ type: "text"; text: string }>;
-} => {
-  const message = (() => {
-    if (error instanceof ZodError) {
-      return formatZodError(error);
-    }
-    if (error instanceof Error) {
-      return error.message;
-    }
-    return "不明なエラーが発生しました";
-  })();
-
-  const errorOutput = {
-    error: message,
-    // エラー時でも最小限のmove情報を含める（スキーマ準拠のため）
-    move: {
-      type: "unknown",
-      power: 0,
-      category: "unknown",
-    },
-  };
-
-  return {
-    isError: true,
-    content: [
-      {
-        type: "text",
-        text: JSON.stringify(errorOutput, null, 2),
-      },
-    ],
-  };
+export const formatError = (error: unknown) => {
+  return baseFormatError(error, DEFAULT_ERROR_OUTPUT);
 };

--- a/src/tools/calculateStatus/handlers/helpers/formatError.ts
+++ b/src/tools/calculateStatus/handlers/helpers/formatError.ts
@@ -1,76 +1,19 @@
-import { ZodError } from "zod";
+import { formatError as baseFormatError } from "@/utils/error";
 
-/**
- * ZodErrorを分かりやすいメッセージに変換する
- */
-const formatZodError = (error: ZodError): string => {
-  const issues = error.issues.map((issue) => {
-    const path = issue.path.join(".");
-
-    switch (issue.code) {
-      case "invalid_type":
-        if (issue.received === "undefined") {
-          return `「${path}」フィールドが必須です`;
-        }
-        return `「${path}」は${issue.expected}型である必要があります（現在: ${issue.received}型）`;
-
-      case "invalid_union":
-        return `「${path}」の形式が正しくありません`;
-
-      case "too_small":
-        return `「${path}」は${issue.minimum}以上である必要があります`;
-
-      case "too_big":
-        return `「${path}」は${issue.maximum}以下である必要があります`;
-
-      case "invalid_enum_value":
-        return `「${path}」は次のいずれかの値である必要があります: ${issue.options.join(", ")}`;
-
-      default:
-        return `「${path}」: ${issue.message}`;
-    }
-  });
-
-  return `入力エラー:\n${issues.join("\n")}`;
+// calculateStatus用のデフォルトエラー出力
+const DEFAULT_ERROR_OUTPUT = {
+  // エラー時でも最小限の情報を含める（スキーマ準拠のため）
+  pokemonName: "unknown",
+  stats: {
+    hp: 0,
+    atk: 0,
+    def: 0,
+    spa: 0,
+    spd: 0,
+    spe: 0,
+  },
 };
 
-export const formatError = (
-  error: unknown,
-): {
-  isError: true;
-  content: Array<{ type: "text"; text: string }>;
-} => {
-  const message = (() => {
-    if (error instanceof ZodError) {
-      return formatZodError(error);
-    }
-    if (error instanceof Error) {
-      return error.message;
-    }
-    return "不明なエラーが発生しました";
-  })();
-
-  const errorOutput = {
-    error: message,
-    // エラー時でも最小限の情報を含める（スキーマ準拠のため）
-    pokemonName: "unknown",
-    stats: {
-      hp: 0,
-      atk: 0,
-      def: 0,
-      spa: 0,
-      spd: 0,
-      spe: 0,
-    },
-  };
-
-  return {
-    isError: true,
-    content: [
-      {
-        type: "text",
-        text: JSON.stringify(errorOutput, null, 2),
-      },
-    ],
-  };
+export const formatError = (error: unknown) => {
+  return baseFormatError(error, DEFAULT_ERROR_OUTPUT);
 };

--- a/src/utils/error/formatError.ts
+++ b/src/utils/error/formatError.ts
@@ -1,0 +1,41 @@
+import { ZodError } from "zod";
+import { formatZodError } from "./formatZodError";
+
+/**
+ * エラーをMCPレスポンス形式にフォーマットする
+ *
+ * @param error - フォーマットするエラー
+ * @param defaultErrorOutput - エラー時のデフォルト出力（ツール固有のスキーマ準拠用）
+ */
+export const formatError = <T extends Record<string, unknown>>(
+  error: unknown,
+  defaultErrorOutput: T,
+): {
+  isError: true;
+  content: Array<{ type: "text"; text: string }>;
+} => {
+  const message = (() => {
+    if (error instanceof ZodError) {
+      return formatZodError(error);
+    }
+    if (error instanceof Error) {
+      return error.message;
+    }
+    return "不明なエラーが発生しました";
+  })();
+
+  const errorOutput = {
+    error: message,
+    ...defaultErrorOutput,
+  };
+
+  return {
+    isError: true,
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify(errorOutput, null, 2),
+      },
+    ],
+  };
+};

--- a/src/utils/error/formatZodError.ts
+++ b/src/utils/error/formatZodError.ts
@@ -1,0 +1,53 @@
+import type { ZodError } from "zod";
+
+/**
+ * ZodErrorを分かりやすいメッセージに変換する
+ */
+export const formatZodError = (error: ZodError): string => {
+  const issues = error.issues.map((issue) => {
+    const path = issue.path.join(".");
+
+    switch (issue.code) {
+      case "invalid_type":
+        if (issue.received === "undefined") {
+          return `「${path}」フィールドが必須です`;
+        }
+        return `「${path}」は${issue.expected}型である必要があります（現在: ${issue.received}型）`;
+
+      case "invalid_union": {
+        // Unionタイプの検証失敗時は、最初の失敗理由から必須フィールドエラーを判定
+        const unionErrors = error.errors.filter(
+          (e) => e.path.join(".") === path,
+        );
+        if (
+          unionErrors.some(
+            (e) => e.code === "invalid_type" && e.received === "undefined",
+          )
+        ) {
+          return `「${path}」フィールドが必須です`;
+        }
+
+        // moveフィールドの場合は特別なメッセージを返す
+        if (path === "move") {
+          return '「move」は文字列（わざ名）または { type: "タイプ名", power: 威力 } の形式で指定してください';
+        }
+
+        return `「${path}」の形式が正しくありません`;
+      }
+
+      case "too_small":
+        return `「${path}」は${issue.minimum}以上である必要があります`;
+
+      case "too_big":
+        return `「${path}」は${issue.maximum}以下である必要があります`;
+
+      case "invalid_enum_value":
+        return `「${path}」は次のいずれかの値である必要があります: ${issue.options.join(", ")}`;
+
+      default:
+        return `「${path}」: ${issue.message}`;
+    }
+  });
+
+  return `入力エラー:\n${issues.join("\n")}`;
+};

--- a/src/utils/error/index.ts
+++ b/src/utils/error/index.ts
@@ -1,0 +1,2 @@
+export { formatError } from "./formatError";
+export { formatZodError } from "./formatZodError";


### PR DESCRIPTION
## Summary
- formatZodError関数とformatError関数の重複を解消
- ダメージ計算ハンドラー内の重複コードを削減
- similarity-tsによる重複検出結果を改善

## 変更内容

### 1. エラーハンドリングの共通化
- `src/utils/error/`ディレクトリを新規作成
- `formatZodError`関数を共通モジュールとして抽出（97.47%の重複を完全に解消）
- `formatError`関数をジェネリック化し、ツール固有のデフォルト出力を引数で受け取る設計に変更

### 2. ダメージ計算ハンドラーの重複削減
- `createCalculationResponse`関数を追加して、MCPレスポンス形式への変換処理を共通化
- 各ハンドラー関数（handleAttackerEvCalculation、handleDefenderEvCalculation、handleNormalCalculation）から重複コードを削除

### 効果
- コードの保守性向上
- DRY原則の遵守
- 重複コードスコアの削減（最大28.2ポイント → 19.8ポイント）

## Test plan
- [x] 全テスト（231件）が成功
- [x] 型チェック（`npm run typecheck`）エラーなし
- [x] リント（`npm run lint`）エラーなし
- [x] similarity-tsで重複コードが削減されたことを確認