### PR TITLE
fix: コメント内の独自用語を正しいわざ名に修正

### DIFF
--- a/src/utils/calculateDamageCore/calculateDamageCore.spec.ts
+++ b/src/utils/calculateDamageCore/calculateDamageCore.spec.ts
@@ -98,7 +98,7 @@ describe("calculateDamageCore", () => {
     expect(result[0]).toBe(113); // 防御半減、タイプ一致1.5倍、タイプ相性0.5倍
   });
 
-  it("チャージ効果を適用", () => {
+  it("じゅうでん効果を適用", () => {
     const params: DamageCoreParams = {
       move: {
         type: "でんき",
@@ -119,10 +119,10 @@ describe("calculateDamageCore", () => {
     };
 
     const result = calculateDamageCore(params);
-    expect(result[0]).toBe(156); // タイプ相性2倍 × チャージ2倍
+    expect(result[0]).toBe(156); // タイプ相性2倍 × じゅうでん2倍
   });
 
-  it("壁効果を適用", () => {
+  it("ひかりのかべ・リフレクター効果を適用", () => {
     const params: DamageCoreParams = {
       move: {
         type: "かくとう",
@@ -143,10 +143,10 @@ describe("calculateDamageCore", () => {
     };
 
     const result = calculateDamageCore(params);
-    expect(result[0]).toBe(39); // タイプ相性2倍 × 壁0.5倍
+    expect(result[0]).toBe(39); // タイプ相性2倍 × リフレクター0.5倍
   });
 
-  it("スポーツ効果を適用", () => {
+  it("どろあそび・みずあそび効果を適用", () => {
     const params: DamageCoreParams = {
       move: {
         type: "でんき",
@@ -167,7 +167,7 @@ describe("calculateDamageCore", () => {
     };
 
     const result = calculateDamageCore(params);
-    expect(result[0]).toBe(19); // スポーツ0.5倍
+    expect(result[0]).toBe(19); // どろあそび0.5倍
   });
 
   it("とくせい効果を適用", () => {

--- a/src/utils/calculateDamageCore/calculateDamageCore.ts
+++ b/src/utils/calculateDamageCore/calculateDamageCore.ts
@@ -86,13 +86,13 @@ export const calculateDamageCore = (params: DamageCoreParams): number[] => {
     return typeAdjustedDamage;
   })();
 
-  // チャージ効果
+  // じゅうでん効果
   const chargeAdjustedDamage =
     options.charge && move.type === "でんき"
       ? Math.floor(weatherAdjustedDamage * 2)
       : weatherAdjustedDamage;
 
-  // 壁効果
+  // ひかりのかべ・リフレクター効果
   const screenAdjustedDamage = (() => {
     if (move.isPhysical && options.reflect) {
       return Math.floor(chargeAdjustedDamage * 0.5);
@@ -103,7 +103,7 @@ export const calculateDamageCore = (params: DamageCoreParams): number[] => {
     return chargeAdjustedDamage;
   })();
 
-  // スポーツ効果
+  // どろあそび・みずあそび効果
   const sportAdjustedDamage = (() => {
     if (options.mudSport && move.type === "でんき") {
       return Math.floor(screenAdjustedDamage * 0.5);

--- a/src/utils/calculateDamageWithContext/calculateDamageWithContext.spec.ts
+++ b/src/utils/calculateDamageWithContext/calculateDamageWithContext.spec.ts
@@ -36,7 +36,7 @@ describe("calculateDamageWithContext", () => {
       expect(result[15]).toBe(69); // 実際の最大ダメージ
     });
 
-    it("壁効果（リフレクター）の処理方法の違い", () => {
+    it("ひかりのかべ・リフレクター効果の処理方法の違い", () => {
       const params: DamageCalculationParams = {
         move: {
           type: "かくとう",
@@ -66,7 +66,7 @@ describe("calculateDamageWithContext", () => {
       expect(result[0]).toBe(39); // 実際のダメージ
     });
 
-    it("チャージ効果の処理タイミングの違い", () => {
+    it("じゅうでん効果の処理タイミングの違い", () => {
       const params: DamageCalculationParams = {
         move: {
           type: "でんき",
@@ -92,11 +92,11 @@ describe("calculateDamageWithContext", () => {
 
       const result = calculateDamageWithContext(params);
       // calculateDamageWithContextは威力に適用
-      // チャージ効果はダメージ計算後に適用
+      // じゅうでん効果はダメージ計算後に適用
       expect(result[0]).toBe(156); // 実際の値
     });
 
-    it("スポーツ効果（どろあそび）の処理タイミング", () => {
+    it("どろあそび・みずあそび効果の処理タイミング", () => {
       const params: DamageCalculationParams = {
         move: {
           type: "でんき",
@@ -122,7 +122,7 @@ describe("calculateDamageWithContext", () => {
 
       const result = calculateDamageWithContext(params);
       // calculateDamageWithContextは威力に適用
-      // スポーツ効果はダメージ計算後に適用
+      // どろあそび効果はダメージ計算後に適用
       expect(result[0]).toBe(19); // 実際のダメージ
     });
 


### PR DESCRIPTION
## Summary
- コード内のコメントで使用されていた独自用語を正しいわざ名に修正
- Issue #61 の対応

## 変更内容
- 「チャージ効果」→「じゅうでん効果」
- 「壁効果」→「ひかりのかべ・リフレクター効果」  
- 「スポーツ効果」→「どろあそび・みずあそび効果」

## 変更ファイル
- `src/utils/calculateDamageCore/calculateDamageCore.ts`
- `src/utils/calculateDamageCore/calculateDamageCore.spec.ts`
- `src/utils/calculateDamageWithContext/calculateDamageWithContext.spec.ts`

## Test plan
- [x] `npm run check` が成功することを確認
- [x] すべてのテストが通過することを確認
- [x] 型チェックが通過することを確認
- [x] リントチェックが通過することを確認

Fixes #61