### PR TITLE
refactor: とくせいデータの渡し方を改善

### DIFF
--- a/src/tools/calculateDamage/handlers/helpers/abilityEffects/abilityEffects.spec.ts
+++ b/src/tools/calculateDamage/handlers/helpers/abilityEffects/abilityEffects.spec.ts
@@ -7,7 +7,7 @@ describe("applyAbilityEffects", () => {
       damage: 100,
       moveType: "じめん",
       attackerAbility: undefined,
-      defenderAbility: "ふゆう",
+      defenderAbility: { name: "ふゆう", description: "" },
     });
     expect(result).toBe(0);
   });
@@ -16,7 +16,7 @@ describe("applyAbilityEffects", () => {
     const result = applyAbilityEffects({
       damage: 100,
       moveType: "ノーマル",
-      attackerAbility: "ちからもち",
+      attackerAbility: { name: "ちからもち", description: "" },
       defenderAbility: undefined,
       isPhysical: true,
     });
@@ -27,7 +27,7 @@ describe("applyAbilityEffects", () => {
     const result = applyAbilityEffects({
       damage: 100,
       moveType: "ノーマル",
-      attackerAbility: "ヨガパワー",
+      attackerAbility: { name: "ヨガパワー", description: "" },
       defenderAbility: undefined,
       isPhysical: true,
     });
@@ -38,7 +38,7 @@ describe("applyAbilityEffects", () => {
     const result = applyAbilityEffects({
       damage: 100,
       moveType: "ノーマル",
-      attackerAbility: "はりきり",
+      attackerAbility: { name: "はりきり", description: "" },
       defenderAbility: undefined,
       isPhysical: true,
     });
@@ -49,7 +49,7 @@ describe("applyAbilityEffects", () => {
     const result = applyAbilityEffects({
       damage: 100,
       moveType: "エスパー",
-      attackerAbility: "ちからもち",
+      attackerAbility: { name: "ちからもち", description: "" },
       defenderAbility: undefined,
       isPhysical: false,
     });
@@ -61,7 +61,7 @@ describe("applyAbilityEffects", () => {
       damage: 100,
       moveType: "でんき",
       attackerAbility: undefined,
-      defenderAbility: "ふゆう",
+      defenderAbility: { name: "ふゆう", description: "" },
     });
     expect(result).toBe(100);
   });
@@ -71,7 +71,7 @@ describe("applyAbilityEffects", () => {
       damage: 50,
       moveType: "ノーマル",
       attackerAbility: undefined,
-      defenderAbility: "ふしぎなまもり",
+      defenderAbility: { name: "ふしぎなまもり", description: "" },
       typeEffectiveness: 1,
     });
     expect(result).toBe(0);
@@ -82,7 +82,7 @@ describe("applyAbilityEffects", () => {
       damage: 100,
       moveType: "いわ",
       attackerAbility: undefined,
-      defenderAbility: "ふしぎなまもり",
+      defenderAbility: { name: "ふしぎなまもり", description: "" },
       typeEffectiveness: 2,
     });
     expect(result).toBe(100);
@@ -114,7 +114,7 @@ describe("applyAbilityEffects", () => {
         const result = applyAbilityEffects({
           damage: 100,
           moveType: "ほのお",
-          attackerAbility: "もうか",
+          attackerAbility: { name: "もうか", description: "" },
           attackerAbilityActive: true,
           defenderAbility: undefined,
         });
@@ -125,7 +125,7 @@ describe("applyAbilityEffects", () => {
         const result = applyAbilityEffects({
           damage: 100,
           moveType: "みず",
-          attackerAbility: "もうか",
+          attackerAbility: { name: "もうか", description: "" },
           attackerAbilityActive: true,
           defenderAbility: undefined,
         });
@@ -136,7 +136,7 @@ describe("applyAbilityEffects", () => {
         const result = applyAbilityEffects({
           damage: 100,
           moveType: "ほのお",
-          attackerAbility: "もうか",
+          attackerAbility: { name: "もうか", description: "" },
           attackerAbilityActive: false,
           defenderAbility: undefined,
         });
@@ -149,7 +149,7 @@ describe("applyAbilityEffects", () => {
         const result = applyAbilityEffects({
           damage: 100,
           moveType: "みず",
-          attackerAbility: "げきりゅう",
+          attackerAbility: { name: "げきりゅう", description: "" },
           attackerAbilityActive: true,
           defenderAbility: undefined,
         });
@@ -162,7 +162,7 @@ describe("applyAbilityEffects", () => {
         const result = applyAbilityEffects({
           damage: 100,
           moveType: "くさ",
-          attackerAbility: "しんりょく",
+          attackerAbility: { name: "しんりょく", description: "" },
           attackerAbilityActive: true,
           defenderAbility: undefined,
         });
@@ -175,7 +175,7 @@ describe("applyAbilityEffects", () => {
         const result = applyAbilityEffects({
           damage: 100,
           moveType: "むし",
-          attackerAbility: "むしのしらせ",
+          attackerAbility: { name: "むしのしらせ", description: "" },
           attackerAbilityActive: true,
           defenderAbility: undefined,
         });
@@ -188,7 +188,7 @@ describe("applyAbilityEffects", () => {
         const result = applyAbilityEffects({
           damage: 100,
           moveType: "ノーマル",
-          attackerAbility: "こんじょう",
+          attackerAbility: { name: "こんじょう", description: "" },
           attackerAbilityActive: true,
           defenderAbility: undefined,
           isPhysical: true,
@@ -200,7 +200,7 @@ describe("applyAbilityEffects", () => {
         const result = applyAbilityEffects({
           damage: 100,
           moveType: "エスパー",
-          attackerAbility: "こんじょう",
+          attackerAbility: { name: "こんじょう", description: "" },
           attackerAbilityActive: true,
           defenderAbility: undefined,
           isPhysical: false,
@@ -215,7 +215,7 @@ describe("applyAbilityEffects", () => {
           damage: 150,
           moveType: "ノーマル",
           attackerAbility: undefined,
-          defenderAbility: "ふしぎなうろこ",
+          defenderAbility: { name: "ふしぎなうろこ", description: "" },
           defenderAbilityActive: true,
           isPhysical: true,
         });
@@ -227,7 +227,7 @@ describe("applyAbilityEffects", () => {
           damage: 100,
           moveType: "エスパー",
           attackerAbility: undefined,
-          defenderAbility: "ふしぎなうろこ",
+          defenderAbility: { name: "ふしぎなうろこ", description: "" },
           defenderAbilityActive: true,
           isPhysical: false,
         });
@@ -240,7 +240,7 @@ describe("applyAbilityEffects", () => {
         const result = applyAbilityEffects({
           damage: 100,
           moveType: "でんき",
-          attackerAbility: "プラス",
+          attackerAbility: { name: "プラス", description: "" },
           attackerAbilityActive: true,
           defenderAbility: undefined,
           isPhysical: false,
@@ -252,7 +252,7 @@ describe("applyAbilityEffects", () => {
         const result = applyAbilityEffects({
           damage: 100,
           moveType: "でんき",
-          attackerAbility: "マイナス",
+          attackerAbility: { name: "マイナス", description: "" },
           attackerAbilityActive: true,
           defenderAbility: undefined,
           isPhysical: false,
@@ -264,7 +264,7 @@ describe("applyAbilityEffects", () => {
         const result = applyAbilityEffects({
           damage: 100,
           moveType: "ノーマル",
-          attackerAbility: "プラス",
+          attackerAbility: { name: "プラス", description: "" },
           attackerAbilityActive: true,
           defenderAbility: undefined,
           isPhysical: true,

--- a/src/tools/calculateDamage/handlers/helpers/abilityEffects/abilityEffects.ts
+++ b/src/tools/calculateDamage/handlers/helpers/abilityEffects/abilityEffects.ts
@@ -1,10 +1,11 @@
+import type { Ability } from "@/data/abilities";
 import type { TypeName } from "@/types";
 
 interface ApplyAbilityEffectsParams {
   damage: number;
   moveType: TypeName;
-  attackerAbility?: string;
-  defenderAbility?: string;
+  attackerAbility?: Ability;
+  defenderAbility?: Ability;
   attackerAbilityActive?: boolean;
   defenderAbilityActive?: boolean;
   typeEffectiveness?: number;
@@ -27,12 +28,12 @@ export const applyAbilityEffects = (
 
   // 防御側とくせいによる無効化チェック（早期return）
   if (defenderAbility) {
-    if (defenderAbility === "ふゆう" && moveType === "じめん") {
+    if (defenderAbility.name === "ふゆう" && moveType === "じめん") {
       return 0;
     }
 
     if (
-      defenderAbility === "ふしぎなまもり" &&
+      defenderAbility.name === "ふしぎなまもり" &&
       typeEffectiveness !== undefined &&
       typeEffectiveness <= 1
     ) {
@@ -49,14 +50,14 @@ export const applyAbilityEffects = (
     // 常時発動とくせい
     const constantAbilityDamage = (() => {
       if (
-        (attackerAbility === "ちからもち" ||
-          attackerAbility === "ヨガパワー") &&
+        (attackerAbility.name === "ちからもち" ||
+          attackerAbility.name === "ヨガパワー") &&
         isPhysical
       ) {
         return Math.floor(damage * 2);
       }
 
-      if (attackerAbility === "はりきり" && isPhysical) {
+      if (attackerAbility.name === "はりきり" && isPhysical) {
         return Math.floor(damage * 1.5);
       }
 
@@ -70,22 +71,23 @@ export const applyAbilityEffects = (
 
     // HP1/3以下で発動するタイプ強化とくせい
     if (
-      (attackerAbility === "もうか" && moveType === "ほのお") ||
-      (attackerAbility === "げきりゅう" && moveType === "みず") ||
-      (attackerAbility === "しんりょく" && moveType === "くさ") ||
-      (attackerAbility === "むしのしらせ" && moveType === "むし")
+      (attackerAbility.name === "もうか" && moveType === "ほのお") ||
+      (attackerAbility.name === "げきりゅう" && moveType === "みず") ||
+      (attackerAbility.name === "しんりょく" && moveType === "くさ") ||
+      (attackerAbility.name === "むしのしらせ" && moveType === "むし")
     ) {
       return Math.floor(constantAbilityDamage * 1.5);
     }
 
     // こんじょう（状態異常時、物理攻撃1.5倍）
-    if (attackerAbility === "こんじょう" && isPhysical) {
+    if (attackerAbility.name === "こんじょう" && isPhysical) {
       return Math.floor(constantAbilityDamage * 1.5);
     }
 
     // プラス/マイナス（ダブルバトルで相手がプラス/マイナス持ちの時、特殊攻撃1.5倍）
     if (
-      (attackerAbility === "プラス" || attackerAbility === "マイナス") &&
+      (attackerAbility.name === "プラス" ||
+        attackerAbility.name === "マイナス") &&
       !isPhysical
     ) {
       return Math.floor(constantAbilityDamage * 1.5);
@@ -96,7 +98,8 @@ export const applyAbilityEffects = (
 
   // 防御側とくせいによるダメージ軽減
   if (
-    defenderAbility === "ふしぎなうろこ" &&
+    defenderAbility &&
+    defenderAbility.name === "ふしぎなうろこ" &&
     defenderAbilityActive &&
     isPhysical
   ) {

--- a/src/tools/calculateDamageMatrixVaryingAttack/handlers/handler.ts
+++ b/src/tools/calculateDamageMatrixVaryingAttack/handlers/handler.ts
@@ -140,7 +140,7 @@ const calculateDamageMatrix = (
         level: attacker.level,
         statModifier: attacker.statModifier,
         pokemon: attacker.pokemon,
-        ability: attacker.ability ? { name: attacker.ability.name } : undefined,
+        ability: attacker.ability,
         abilityActive: attacker.abilityActive,
         item: attacker.item ? { name: attacker.item.name } : undefined,
         pokemonName: attacker.pokemonName,
@@ -148,7 +148,7 @@ const calculateDamageMatrix = (
       defender: {
         statModifier: defender.statModifier,
         pokemon: defender.pokemon,
-        ability: defender.ability ? { name: defender.ability.name } : undefined,
+        ability: defender.ability,
         abilityActive: defender.abilityActive,
         item: defender.item ? { name: defender.item.name } : undefined,
         pokemonName: defender.pokemonName,

--- a/src/tools/calculateDamageMatrixVaryingDefense/handlers/handler.ts
+++ b/src/tools/calculateDamageMatrixVaryingDefense/handlers/handler.ts
@@ -152,7 +152,7 @@ const calculateDamageMatrix = (
         level: attacker.level,
         statModifier: attacker.statModifier,
         pokemon: attacker.pokemon,
-        ability: attacker.ability ? { name: attacker.ability.name } : undefined,
+        ability: attacker.ability,
         abilityActive: attacker.abilityActive,
         item: attacker.item ? { name: attacker.item.name } : undefined,
         pokemonName: attacker.pokemonName,
@@ -160,7 +160,7 @@ const calculateDamageMatrix = (
       defender: {
         statModifier: defender.statModifier,
         pokemon: defender.pokemon,
-        ability: defender.ability ? { name: defender.ability.name } : undefined,
+        ability: defender.ability,
         abilityActive: defender.abilityActive,
         item: defender.item ? { name: defender.item.name } : undefined,
         pokemonName: defender.pokemonName,

--- a/src/utils/calculateDamageCore/calculateDamageCore.spec.ts
+++ b/src/utils/calculateDamageCore/calculateDamageCore.spec.ts
@@ -180,7 +180,7 @@ describe("calculateDamageCore", () => {
       attacker: {
         level: 50,
         attackStat: 100,
-        ability: { name: "げきりゅう" },
+        ability: { name: "げきりゅう", description: "" },
         abilityActive: true,
       },
       defender: {
@@ -205,13 +205,13 @@ describe("calculateDamageCore", () => {
         level: 50,
         attackStat: 100,
         types: ["みず"],
-        ability: { name: "げきりゅう" },
+        ability: { name: "げきりゅう", description: "" },
         abilityActive: true,
       },
       defender: {
         defenseStat: 100,
         types: ["ほのお"],
-        ability: { name: "あついしぼう" },
+        ability: { name: "あついしぼう", description: "" },
         abilityActive: false,
       },
       options: {

--- a/src/utils/calculateDamageCore/calculateDamageCore.ts
+++ b/src/utils/calculateDamageCore/calculateDamageCore.ts
@@ -1,3 +1,4 @@
+import type { Ability } from "@/data/abilities";
 import { applyAbilityEffects } from "@/tools/calculateDamage/handlers/helpers/abilityEffects";
 import { calculateBaseDamage } from "@/tools/calculateDamage/handlers/helpers/calculateBaseDamage";
 import { getDamageRanges } from "@/tools/calculateDamage/handlers/helpers/damageRanges";
@@ -16,13 +17,13 @@ export interface DamageCoreParams {
     level: number;
     attackStat: number;
     types?: TypeName[];
-    ability?: { name?: string };
+    ability?: Ability;
     abilityActive?: boolean;
   };
   defender: {
     defenseStat: number;
     types: TypeName[];
-    ability?: { name?: string };
+    ability?: Ability;
     abilityActive?: boolean;
   };
   options: {
@@ -119,9 +120,9 @@ export const calculateDamageCore = (params: DamageCoreParams): number[] => {
   const abilityAdjustedDamage = applyAbilityEffects({
     damage: sportAdjustedDamage,
     moveType: move.type,
-    attackerAbility: attacker.ability?.name,
+    attackerAbility: attacker.ability,
     attackerAbilityActive: attacker.abilityActive,
-    defenderAbility: defender.ability?.name,
+    defenderAbility: defender.ability,
     defenderAbilityActive: defender.abilityActive,
     typeEffectiveness,
     isPhysical: move.isPhysical,

--- a/src/utils/calculateDamageWithContext/calculateDamageWithContext.spec.ts
+++ b/src/utils/calculateDamageWithContext/calculateDamageWithContext.spec.ts
@@ -263,7 +263,7 @@ describe("calculateDamageWithContext", () => {
         attacker: {
           level: 50,
           statModifier: 0,
-          ability: { name: "げきりゅう" },
+          ability: { name: "げきりゅう", description: "" },
           abilityActive: true,
         },
         defender: {

--- a/src/utils/calculateDamageWithContext/calculateDamageWithContext.ts
+++ b/src/utils/calculateDamageWithContext/calculateDamageWithContext.ts
@@ -1,3 +1,4 @@
+import type { Ability } from "@/data/abilities";
 import { calculateItemEffects } from "@/tools/calculateDamage/handlers/helpers/itemEffects";
 import { getStatModifierRatio } from "@/tools/calculateDamage/handlers/helpers/statModifier";
 import type { TypeName } from "@/types";
@@ -17,7 +18,7 @@ export interface DamageCalculationParams {
     level: number;
     statModifier: number;
     pokemon?: { types?: TypeName[] };
-    ability?: { name?: string };
+    ability?: Ability;
     abilityActive?: boolean;
     item?: { name?: string };
     pokemonName?: string;
@@ -25,7 +26,7 @@ export interface DamageCalculationParams {
   defender: {
     statModifier: number;
     pokemon?: { types?: TypeName[]; weightkg?: number };
-    ability?: { name?: string };
+    ability?: Ability;
     abilityActive?: boolean;
     item?: { name?: string };
     pokemonName?: string;


### PR DESCRIPTION
## Summary
- applyAbilityEffects関数のインターフェースを改善し、Abilityオブジェクトを直接渡すように変更
- 不要なオプショナルチェーンを削除し、コードの可読性を向上
- 関連する全ての呼び出し元を修正

## Changes
1. **applyAbilityEffects関数のインターフェース変更**
   - `attackerAbility?: string` → `attackerAbility?: Ability`
   - `defenderAbility?: string` → `defenderAbility?: Ability`
   - 関数内部で`ability.name`でアクセスするように修正

2. **不要なオプショナルチェーンの削除**
   - `defenderAbility?.name` → `defenderAbility && defenderAbility.name`

3. **関連ファイルの修正**
   - calculateDamageCore: 不要な`?.name`を削除
   - calculateDamageWithContext: Ability型に対応
   - Matrix系ハンドラ: 不要な変換処理を削除

## Test plan
- [x] 全てのテストが通ることを確認 (`npm run test`)
- [x] 型チェックが通ることを確認 (`npm run typecheck`)
- [x] リントエラーがないことを確認 (`npm run lint`)

Fixes #68