### PR TITLE
refactor: itemオブジェクトとitemNameの混在を解消 (#72)

### DIFF
--- a/src/tools/calculateDamage/handlers/helpers/calculateDamage/calculateDamage.ts
+++ b/src/tools/calculateDamage/handlers/helpers/calculateDamage/calculateDamage.ts
@@ -1,5 +1,5 @@
 import type { Ability } from "@/data/abilities";
-import type { Item, ItemName } from "@/data/items";
+import type { Item } from "@/data/items";
 import type { CalculateDamageInput } from "@/tools/calculateDamage/handlers/schemas/damageSchema";
 import type { DamageOptions } from "@/tools/calculateDamage/types";
 import type { TypeName } from "@/types";
@@ -48,14 +48,14 @@ const calculateDamageInternal = (params: InternalDamageParams): number[] => {
   const { move, attacker, defender, options } = params;
 
   const attackerItemEffects = calculateItemEffects(
-    attacker.item?.name as ItemName | undefined,
+    attacker.item,
     attacker.pokemonName,
     move.type,
     move.isPhysical,
   );
 
   const defenderItemEffects = calculateItemEffects(
-    defender.item?.name as ItemName | undefined,
+    defender.item,
     defender.pokemonName,
     move.type,
     move.isPhysical,

--- a/src/tools/calculateDamage/handlers/helpers/itemEffects/itemEffects.spec.ts
+++ b/src/tools/calculateDamage/handlers/helpers/itemEffects/itemEffects.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { ItemName } from "@/data/items";
+import type { Item } from "@/data/items";
 import type { TypeName } from "@/types";
 import { calculateItemEffects } from "./itemEffects";
 
@@ -26,7 +26,7 @@ describe("calculateItemEffects", () => {
   describe("タイプ強化アイテム", () => {
     it("もくたん: ほのおタイプの物理技で攻撃1.1倍", () => {
       const result = calculateItemEffects(
-        "もくたん",
+        { name: "もくたん", description: "" },
         "リザードン",
         "ほのお",
         true,
@@ -43,7 +43,7 @@ describe("calculateItemEffects", () => {
 
     it("もくたん: ほのおタイプの特殊技で特攻1.1倍", () => {
       const result = calculateItemEffects(
-        "もくたん",
+        { name: "もくたん", description: "" },
         "リザードン",
         "ほのお",
         false,
@@ -57,7 +57,7 @@ describe("calculateItemEffects", () => {
 
     it("しんぴのしずく: みずタイプの技で効果発動", () => {
       const result = calculateItemEffects(
-        "しんぴのしずく",
+        { name: "しんぴのしずく", description: "" },
         "カメックス",
         "みず",
         false,
@@ -70,7 +70,7 @@ describe("calculateItemEffects", () => {
 
     it("タイプ不一致の場合は効果なし", () => {
       const result = calculateItemEffects(
-        "もくたん",
+        { name: "もくたん", description: "" },
         "フシギダネ",
         "くさ",
         true,
@@ -86,7 +86,7 @@ describe("calculateItemEffects", () => {
   describe("特殊効果アイテム", () => {
     it("こだわりハチマキ: 攻撃1.5倍、技固定", () => {
       const result = calculateItemEffects(
-        "こだわりハチマキ",
+        { name: "こだわりハチマキ", description: "" },
         "リザードン",
         "ドラゴン",
         true,
@@ -97,7 +97,7 @@ describe("calculateItemEffects", () => {
 
     it("でんきだま: ピカチュウの特攻2倍", () => {
       const result = calculateItemEffects(
-        "でんきだま",
+        { name: "でんきだま", description: "" },
         "ピカチュウ",
         "でんき",
         false,
@@ -110,7 +110,7 @@ describe("calculateItemEffects", () => {
 
     it("でんきだま: ピカチュウ以外には効果なし", () => {
       const result = calculateItemEffects(
-        "でんきだま",
+        { name: "でんきだま", description: "" },
         "ライチュウ",
         "でんき",
         false,
@@ -123,7 +123,7 @@ describe("calculateItemEffects", () => {
 
     it("ふといホネ: カラカラの攻撃2倍", () => {
       const result = calculateItemEffects(
-        "ふといホネ",
+        { name: "ふといホネ", description: "" },
         "カラカラ",
         "じめん",
         true,
@@ -133,7 +133,7 @@ describe("calculateItemEffects", () => {
 
     it("ふといホネ: ガラガラの攻撃2倍", () => {
       const result = calculateItemEffects(
-        "ふといホネ",
+        { name: "ふといホネ", description: "" },
         "ガラガラ",
         "じめん",
         true,
@@ -143,7 +143,7 @@ describe("calculateItemEffects", () => {
 
     it("しんかいのキバ: パールルの特攻2倍", () => {
       const result = calculateItemEffects(
-        "しんかいのキバ",
+        { name: "しんかいのキバ", description: "" },
         "パールル",
         "みず",
         false,
@@ -156,7 +156,7 @@ describe("calculateItemEffects", () => {
 
     it("こころのしずく: ラティオスの特攻1.5倍", () => {
       const result = calculateItemEffects(
-        "こころのしずく",
+        { name: "こころのしずく", description: "" },
         "ラティオス",
         "エスパー",
         false,
@@ -169,7 +169,7 @@ describe("calculateItemEffects", () => {
 
     it("こころのしずく: ラティアスの特攻1.5倍", () => {
       const result = calculateItemEffects(
-        "こころのしずく",
+        { name: "こころのしずく", description: "" },
         "ラティアス",
         "エスパー",
         false,
@@ -184,7 +184,7 @@ describe("calculateItemEffects", () => {
   describe("防御系アイテム", () => {
     it("メタルパウダー: メタモンの防御2倍", () => {
       const result = calculateItemEffects(
-        "メタルパウダー",
+        { name: "メタルパウダー", description: "" },
         "メタモン",
         "ノーマル",
         true,
@@ -197,7 +197,7 @@ describe("calculateItemEffects", () => {
 
     it("メタルパウダー: メタモン以外には効果なし", () => {
       const result = calculateItemEffects(
-        "メタルパウダー",
+        { name: "メタルパウダー", description: "" },
         "ピカチュウ",
         "でんき",
         true,
@@ -210,7 +210,7 @@ describe("calculateItemEffects", () => {
 
     it("しんかいのウロコ: パールルの特防2倍", () => {
       const result = calculateItemEffects(
-        "しんかいのウロコ",
+        { name: "しんかいのウロコ", description: "" },
         "パールル",
         "みず",
         false,
@@ -223,7 +223,7 @@ describe("calculateItemEffects", () => {
 
     it("しんかいのウロコ: パールル以外には効果なし", () => {
       const result = calculateItemEffects(
-        "しんかいのウロコ",
+        { name: "しんかいのウロコ", description: "" },
         "ハンテール",
         "みず",
         false,
@@ -236,7 +236,7 @@ describe("calculateItemEffects", () => {
 
     it("こころのしずく: ラティオスの特攻と特防1.5倍", () => {
       const result = calculateItemEffects(
-        "こころのしずく",
+        { name: "こころのしずく", description: "" },
         "ラティオス",
         "エスパー",
         false,
@@ -253,7 +253,7 @@ describe("calculateItemEffects", () => {
 
     it("こころのしずく: ラティアスの特攻と特防1.5倍", () => {
       const result = calculateItemEffects(
-        "こころのしずく",
+        { name: "こころのしずく", description: "" },
         "ラティアス",
         "ドラゴン",
         false,
@@ -270,26 +270,26 @@ describe("calculateItemEffects", () => {
   });
 
   describe("複数のタイプ強化アイテムのテスト", () => {
-    const typeItems: Array<{ item: ItemName; type: TypeName }> = [
-      { item: "きせきのタネ", type: "くさ" },
-      { item: "じしゃく", type: "でんき" },
-      { item: "とけないこおり", type: "こおり" },
-      { item: "どくバリ", type: "どく" },
-      { item: "やわらかいすな", type: "じめん" },
-      { item: "かたいいし", type: "いわ" },
-      { item: "ぎんのこな", type: "むし" },
-      { item: "のろいのおふだ", type: "ゴースト" },
-      { item: "りゅうのキバ", type: "ドラゴン" },
-      { item: "くろいメガネ", type: "あく" },
-      { item: "メタルコート", type: "はがね" },
-      { item: "シルクのスカーフ", type: "ノーマル" },
-      { item: "くろおび", type: "かくとう" },
-      { item: "するどいくちばし", type: "ひこう" },
-      { item: "まがったスプーン", type: "エスパー" },
+    const typeItems: Array<{ item: Item; type: TypeName }> = [
+      { item: { name: "きせきのタネ", description: "" }, type: "くさ" },
+      { item: { name: "じしゃく", description: "" }, type: "でんき" },
+      { item: { name: "とけないこおり", description: "" }, type: "こおり" },
+      { item: { name: "どくバリ", description: "" }, type: "どく" },
+      { item: { name: "やわらかいすな", description: "" }, type: "じめん" },
+      { item: { name: "かたいいし", description: "" }, type: "いわ" },
+      { item: { name: "ぎんのこな", description: "" }, type: "むし" },
+      { item: { name: "のろいのおふだ", description: "" }, type: "ゴースト" },
+      { item: { name: "りゅうのキバ", description: "" }, type: "ドラゴン" },
+      { item: { name: "くろいメガネ", description: "" }, type: "あく" },
+      { item: { name: "メタルコート", description: "" }, type: "はがね" },
+      { item: { name: "シルクのスカーフ", description: "" }, type: "ノーマル" },
+      { item: { name: "くろおび", description: "" }, type: "かくとう" },
+      { item: { name: "するどいくちばし", description: "" }, type: "ひこう" },
+      { item: { name: "まがったスプーン", description: "" }, type: "エスパー" },
     ];
 
     typeItems.forEach(({ item, type }) => {
-      it(`${item}: ${type}タイプの物理技で攻撃1.1倍`, () => {
+      it(`${item.name}: ${type}タイプの物理技で攻撃1.1倍`, () => {
         const result = calculateItemEffects(item, undefined, type, true);
         expect(result.attackMultiplier).toEqual({
           numerator: 11,
@@ -297,7 +297,7 @@ describe("calculateItemEffects", () => {
         });
       });
 
-      it(`${item}: ${type}タイプの特殊技で特攻1.1倍`, () => {
+      it(`${item.name}: ${type}タイプの特殊技で特攻1.1倍`, () => {
         const result = calculateItemEffects(item, undefined, type, false);
         expect(result.specialAttackMultiplier).toEqual({
           numerator: 11,

--- a/src/tools/calculateDamage/handlers/helpers/itemEffects/itemEffects.ts
+++ b/src/tools/calculateDamage/handlers/helpers/itemEffects/itemEffects.ts
@@ -1,3 +1,4 @@
+import type { Item } from "@/data/items";
 import type { TypeName } from "@/types";
 
 export interface ItemEffectResult {
@@ -10,7 +11,7 @@ export interface ItemEffectResult {
 }
 
 export const calculateItemEffects = (
-  item: string | undefined,
+  item: Item | undefined,
   pokemonName: string | undefined,
   moveType: TypeName,
   isPhysical: boolean,
@@ -48,7 +49,7 @@ export const calculateItemEffects = (
     まがったスプーン: "エスパー",
   };
 
-  const enhancedType = typeEnhancingItems[item];
+  const enhancedType = item.name ? typeEnhancingItems[item.name] : undefined;
   if (enhancedType && enhancedType === moveType) {
     if (isPhysical) {
       return {
@@ -63,7 +64,7 @@ export const calculateItemEffects = (
     }
   }
 
-  switch (item) {
+  switch (item.name) {
     case "こだわりハチマキ":
       return {
         ...defaultResult,

--- a/src/tools/calculateDamageMatrixVaryingAttack/handlers/handler.ts
+++ b/src/tools/calculateDamageMatrixVaryingAttack/handlers/handler.ts
@@ -142,7 +142,7 @@ const calculateDamageMatrix = (
         pokemon: attacker.pokemon,
         ability: attacker.ability,
         abilityActive: attacker.abilityActive,
-        item: attacker.item ? { name: attacker.item.name } : undefined,
+        item: attacker.item,
         pokemonName: attacker.pokemonName,
       },
       defender: {
@@ -150,7 +150,7 @@ const calculateDamageMatrix = (
         pokemon: defender.pokemon,
         ability: defender.ability,
         abilityActive: defender.abilityActive,
-        item: defender.item ? { name: defender.item.name } : undefined,
+        item: defender.item,
         pokemonName: defender.pokemonName,
       },
       options,

--- a/src/tools/calculateDamageMatrixVaryingDefense/handlers/handler.ts
+++ b/src/tools/calculateDamageMatrixVaryingDefense/handlers/handler.ts
@@ -154,7 +154,7 @@ const calculateDamageMatrix = (
         pokemon: attacker.pokemon,
         ability: attacker.ability,
         abilityActive: attacker.abilityActive,
-        item: attacker.item ? { name: attacker.item.name } : undefined,
+        item: attacker.item,
         pokemonName: attacker.pokemonName,
       },
       defender: {
@@ -162,7 +162,7 @@ const calculateDamageMatrix = (
         pokemon: defender.pokemon,
         ability: defender.ability,
         abilityActive: defender.abilityActive,
-        item: defender.item ? { name: defender.item.name } : undefined,
+        item: defender.item,
         pokemonName: defender.pokemonName,
       },
       options,

--- a/src/utils/calculateDamageWithContext/calculateDamageWithContext.ts
+++ b/src/utils/calculateDamageWithContext/calculateDamageWithContext.ts
@@ -1,4 +1,5 @@
 import type { Ability } from "@/data/abilities";
+import type { Item } from "@/data/items";
 import { calculateItemEffects } from "@/tools/calculateDamage/handlers/helpers/itemEffects";
 import { getStatModifierRatio } from "@/tools/calculateDamage/handlers/helpers/statModifier";
 import type { TypeName } from "@/types";
@@ -20,7 +21,7 @@ export interface DamageCalculationParams {
     pokemon?: { types?: TypeName[] };
     ability?: Ability;
     abilityActive?: boolean;
-    item?: { name?: string };
+    item?: Item;
     pokemonName?: string;
   };
   defender: {
@@ -28,7 +29,7 @@ export interface DamageCalculationParams {
     pokemon?: { types?: TypeName[]; weightkg?: number };
     ability?: Ability;
     abilityActive?: boolean;
-    item?: { name?: string };
+    item?: Item;
     pokemonName?: string;
   };
   options: {
@@ -58,14 +59,14 @@ export const calculateDamageWithContext = (
 
   // もちもの効果を計算
   const attackerItemEffects = calculateItemEffects(
-    attacker.item?.name,
+    attacker.item,
     attacker.pokemonName || undefined,
     move.type,
     move.isPhysical,
   );
 
   const defenderItemEffects = calculateItemEffects(
-    defender.item?.name,
+    defender.item,
     defender.pokemonName || undefined,
     move.type,
     move.isPhysical,


### PR DESCRIPTION
## 概要
Issue #72 を解決しました。

## 変更内容
- `calculateItemEffects`関数の引数を`string`型から`Item`型に変更
- 全ての呼び出し箇所で`item?.name as ItemName`のような型キャストを削除
- `calculateDamageWithContext`の型定義も`Item`型に統一
- 関連するテストコードを新しい形式に更新

## 解決した問題
- **型の不整合**: `calculateItemEffects`が文字列を期待しているのに、実際は`Item`オブジェクトが渡されていた
- **型キャストの乱用**: `as`による型キャストが各所で使用されていた
- **可読性の低下**: `item`が文字列なのかオブジェクトなのか不明瞭だった

## テスト
- 全てのテストが通過することを確認済み
- 型チェック、リント、テストすべてパス

Closes #72