### PR TITLE
refactor: pokemonNameとpokemonオブジェクトの使い分けを明確化

### DIFF
--- a/src/tools/calculateDamage/handlers/helpers/calculateDamage/calculateDamage.ts
+++ b/src/tools/calculateDamage/handlers/helpers/calculateDamage/calculateDamage.ts
@@ -23,7 +23,7 @@ interface InternalDamageParams {
     attack: number;
     attackModifier: number;
     types?: TypeName[];
-    pokemonName?: string;
+    pokemon?: { name: string };
     ability?: Ability;
     abilityActive?: boolean;
     item?: Item;
@@ -32,7 +32,7 @@ interface InternalDamageParams {
     defense: number;
     defenseModifier: number;
     types: TypeName[];
-    pokemonName?: string;
+    pokemon?: { name: string };
     ability?: Ability;
     abilityActive?: boolean;
     item?: Item;
@@ -49,14 +49,14 @@ const calculateDamageInternal = (params: InternalDamageParams): number[] => {
 
   const attackerItemEffects = calculateItemEffects(
     attacker.item,
-    attacker.pokemonName,
+    attacker.pokemon?.name,
     move.type,
     move.isPhysical,
   );
 
   const defenderItemEffects = calculateItemEffects(
     defender.item,
-    defender.pokemonName,
+    defender.pokemon?.name,
     move.type,
     move.isPhysical,
   );
@@ -147,7 +147,9 @@ export const calculateNormalDamage = (
       attack: attackStat,
       attackModifier: input.attacker.statModifier,
       types: input.attacker.pokemon?.types,
-      pokemonName: input.attacker.pokemon?.name,
+      pokemon: input.attacker.pokemon
+        ? { name: input.attacker.pokemon.name }
+        : undefined,
       ability: input.attacker.ability,
       abilityActive: input.attacker.abilityActive,
       item: input.attacker.item,
@@ -156,7 +158,9 @@ export const calculateNormalDamage = (
       defense: defenseStat,
       defenseModifier: input.defender.statModifier,
       types: defenderTypes,
-      pokemonName: input.defender.pokemon?.name,
+      pokemon: input.defender.pokemon
+        ? { name: input.defender.pokemon.name }
+        : undefined,
       ability: input.defender.ability,
       abilityActive: input.defender.abilityActive,
       item: input.defender.item,

--- a/src/tools/calculateDamage/handlers/helpers/calculateStats.ts
+++ b/src/tools/calculateDamage/handlers/helpers/calculateStats.ts
@@ -9,14 +9,14 @@ export const getCalculatedStats = (
     stat: input.attacker.stat,
     level: input.attacker.level,
     statName: input.move.isPhysical ? "atk" : "spa",
-    pokemonName: input.attacker.pokemonName,
+    pokemonName: input.attacker.pokemon?.name,
   });
 
   const defenseStat = getStatValue({
     stat: input.defender.stat,
     level: input.defender.level,
     statName: input.move.isPhysical ? "def" : "spd",
-    pokemonName: input.defender.pokemonName,
+    pokemonName: input.defender.pokemon?.name,
   });
 
   return {

--- a/src/tools/calculateDamage/handlers/schemas/damageSchema/damageSchema.spec.ts
+++ b/src/tools/calculateDamage/handlers/schemas/damageSchema/damageSchema.spec.ts
@@ -176,7 +176,7 @@ describe("calculateDamageInputSchema", () => {
       };
 
       const result = calculateDamageInputSchema.parse(input);
-      expect(result.attacker.pokemonName).toBe("ピカチュウ");
+      expect(result.attacker.pokemon?.name).toBe("ピカチュウ");
       expect(result.attacker.stat).toMatchObject({
         iv: 31,
         ev: 252,

--- a/src/tools/calculateDamage/handlers/schemas/damageSchema/damageSchema.ts
+++ b/src/tools/calculateDamage/handlers/schemas/damageSchema/damageSchema.ts
@@ -138,8 +138,10 @@ const createPokemonSchema = () =>
         throw new Error(`とくせい「${input.ability}」が見つかりません`);
       }
 
+      // pokemonNameを削除し、pokemonオブジェクトのみを使用
+      const { pokemonName: _, ...restInput } = input;
       return {
-        ...input,
+        ...restInput,
         pokemon,
         item,
         ability,

--- a/src/tools/calculateDamageMatrixVaryingAttack/handlers/handler.ts
+++ b/src/tools/calculateDamageMatrixVaryingAttack/handlers/handler.ts
@@ -143,7 +143,6 @@ const calculateDamageMatrix = (
         ability: attacker.ability,
         abilityActive: attacker.abilityActive,
         item: attacker.item,
-        pokemonName: attacker.pokemonName,
       },
       defender: {
         statModifier: defender.statModifier,
@@ -151,7 +150,6 @@ const calculateDamageMatrix = (
         ability: defender.ability,
         abilityActive: defender.abilityActive,
         item: defender.item,
-        pokemonName: defender.pokemonName,
       },
       options,
     });

--- a/src/tools/calculateDamageMatrixVaryingAttack/handlers/schemas/damageMatrixVaryingAttackSchema/damageMatrixVaryingAttackSchema.spec.ts
+++ b/src/tools/calculateDamageMatrixVaryingAttack/handlers/schemas/damageMatrixVaryingAttackSchema/damageMatrixVaryingAttackSchema.spec.ts
@@ -221,7 +221,7 @@ describe("calculateDamageMatrixVaryingAttackInputSchema", () => {
       };
 
       const result = calculateDamageMatrixVaryingAttackInputSchema.parse(input);
-      expect(result.defender.pokemonName).toBeUndefined();
+      expect(result.defender.pokemon).toBeUndefined();
     });
   });
 

--- a/src/tools/calculateDamageMatrixVaryingAttack/handlers/schemas/damageMatrixVaryingAttackSchema/damageMatrixVaryingAttackSchema.ts
+++ b/src/tools/calculateDamageMatrixVaryingAttack/handlers/schemas/damageMatrixVaryingAttackSchema/damageMatrixVaryingAttackSchema.ts
@@ -145,8 +145,10 @@ const attackerSchema = z
       throw new Error(`とくせい「${input.ability}」が見つかりません`);
     }
 
+    // pokemonNameを削除し、pokemonオブジェクトのみを使用
+    const { pokemonName: _, ...restInput } = input;
     return {
-      ...input,
+      ...restInput,
       pokemon,
       item,
       ability,
@@ -196,8 +198,10 @@ const defenderSchema = z
       throw new Error(`とくせい「${input.ability}」が見つかりません`);
     }
 
+    // pokemonNameを削除し、pokemonオブジェクトのみを使用
+    const { pokemonName: _, ...restInput } = input;
     return {
-      ...input,
+      ...restInput,
       pokemon,
       item,
       ability,

--- a/src/tools/calculateDamageMatrixVaryingDefense/handlers/handler.ts
+++ b/src/tools/calculateDamageMatrixVaryingDefense/handlers/handler.ts
@@ -155,7 +155,6 @@ const calculateDamageMatrix = (
         ability: attacker.ability,
         abilityActive: attacker.abilityActive,
         item: attacker.item,
-        pokemonName: attacker.pokemonName,
       },
       defender: {
         statModifier: defender.statModifier,
@@ -163,7 +162,6 @@ const calculateDamageMatrix = (
         ability: defender.ability,
         abilityActive: defender.abilityActive,
         item: defender.item,
-        pokemonName: defender.pokemonName,
       },
       options,
     });

--- a/src/tools/calculateDamageMatrixVaryingDefense/handlers/schemas/damageMatrixVaryingDefenseSchema/damageMatrixVaryingDefenseSchema.ts
+++ b/src/tools/calculateDamageMatrixVaryingDefense/handlers/schemas/damageMatrixVaryingDefenseSchema/damageMatrixVaryingDefenseSchema.ts
@@ -146,8 +146,10 @@ const attackerSchema = z
       throw new Error(`とくせい「${input.ability}」が見つかりません`);
     }
 
+    // pokemonNameを削除し、pokemonオブジェクトのみを使用
+    const { pokemonName: _, ...restInput } = input;
     return {
-      ...input,
+      ...restInput,
       pokemon,
       item,
       ability,
@@ -196,8 +198,10 @@ const defenderSchema = z
       throw new Error(`とくせい「${input.ability}」が見つかりません`);
     }
 
+    // pokemonNameを削除し、pokemonオブジェクトのみを使用
+    const { pokemonName: _, ...restInput } = input;
     return {
-      ...input,
+      ...restInput,
       pokemon,
       item,
       ability,

--- a/src/utils/calculateDamageWithContext/calculateDamageWithContext.spec.ts
+++ b/src/utils/calculateDamageWithContext/calculateDamageWithContext.spec.ts
@@ -17,12 +17,14 @@ describe("calculateDamageWithContext", () => {
           level: 50,
           statModifier: 0,
           pokemon: {
+            name: "ポケモン",
             types: ["ノーマル"],
           },
         },
         defender: {
           statModifier: 0,
           pokemon: {
+            name: "ポケモン",
             types: ["ノーマル"],
           },
         },
@@ -52,6 +54,7 @@ describe("calculateDamageWithContext", () => {
         defender: {
           statModifier: 0,
           pokemon: {
+            name: "ポケモン",
             types: ["ノーマル"],
           },
         },
@@ -82,6 +85,7 @@ describe("calculateDamageWithContext", () => {
         defender: {
           statModifier: 0,
           pokemon: {
+            name: "ポケモン",
             types: ["みず"],
           },
         },
@@ -112,6 +116,7 @@ describe("calculateDamageWithContext", () => {
         defender: {
           statModifier: 0,
           pokemon: {
+            name: "ポケモン",
             types: ["ノーマル"],
           },
         },
@@ -141,12 +146,14 @@ describe("calculateDamageWithContext", () => {
             level: 50,
             statModifier: 0,
             pokemon: {
+              name: "ポケモン",
               types: ["ノーマル"],
             },
           },
           defender: {
             statModifier: 0,
             pokemon: {
+              name: "ポケモン",
               types: ["いわ"],
             },
           },
@@ -175,6 +182,7 @@ describe("calculateDamageWithContext", () => {
           defender: {
             statModifier: 0,
             pokemon: {
+              name: "ポケモン",
               types: ["ノーマル"],
             },
           },
@@ -205,6 +213,7 @@ describe("calculateDamageWithContext", () => {
           defender: {
             statModifier: 0,
             pokemon: {
+              name: "カビゴン",
               types: ["ノーマル"],
               weightkg: 460.0, // カビゴンの体重
             },
@@ -231,12 +240,14 @@ describe("calculateDamageWithContext", () => {
           level: 50,
           statModifier: 0,
           pokemon: {
+            name: "ポケモン",
             types: ["みず"],
           },
         },
         defender: {
           statModifier: 0,
           pokemon: {
+            name: "ポケモン",
             types: ["ほのお"],
           },
         },
@@ -269,6 +280,7 @@ describe("calculateDamageWithContext", () => {
         defender: {
           statModifier: 0,
           pokemon: {
+            name: "ポケモン",
             types: ["ほのお"],
           },
         },

--- a/src/utils/calculateDamageWithContext/calculateDamageWithContext.ts
+++ b/src/utils/calculateDamageWithContext/calculateDamageWithContext.ts
@@ -18,19 +18,17 @@ export interface DamageCalculationParams {
   attacker: {
     level: number;
     statModifier: number;
-    pokemon?: { types?: TypeName[] };
+    pokemon?: { name: string; types?: TypeName[] };
     ability?: Ability;
     abilityActive?: boolean;
     item?: Item;
-    pokemonName?: string;
   };
   defender: {
     statModifier: number;
-    pokemon?: { types?: TypeName[]; weightkg?: number };
+    pokemon?: { name: string; types?: TypeName[]; weightkg?: number };
     ability?: Ability;
     abilityActive?: boolean;
     item?: Item;
-    pokemonName?: string;
   };
   options: {
     weather?: "はれ" | "あめ" | "あられ" | "すなあらし";
@@ -60,14 +58,14 @@ export const calculateDamageWithContext = (
   // もちもの効果を計算
   const attackerItemEffects = calculateItemEffects(
     attacker.item,
-    attacker.pokemonName || undefined,
+    attacker.pokemon?.name,
     move.type,
     move.isPhysical,
   );
 
   const defenderItemEffects = calculateItemEffects(
     defender.item,
-    defender.pokemonName || undefined,
+    defender.pokemon?.name,
     move.type,
     move.isPhysical,
   );


### PR DESCRIPTION
## 概要
Issue #73 の内容に従って、`pokemonName`（文字列）と`pokemon`（オブジェクト）の使い分けを明確化するリファクタリングを実施しました。

## 変更内容

### 1. スキーマ層での変更
- `damageSchema.ts`で`pokemonName`を削除し、`pokemon`オブジェクトのみを使用
- `damageMatrixVaryingAttackSchema`と`damageMatrixVaryingDefenseSchema`も同様に修正
- APIレベルでは引き続き`pokemonName`（文字列）を受け取るが、内部では`pokemon`オブジェクトに変換

### 2. 内部処理での統一
- `calculateDamageWithContext.ts`のインターフェースから`pokemonName`を削除
- `pokemon.name`で統一的にアクセスするように変更
- `calculateDamage.ts`も同様に修正

### 3. もちもの効果の計算
- `itemEffects.ts`では引き続き`pokemonName`パラメータを受け取る
- 呼び出し側から`pokemon?.name`を渡すように変更

### 4. テストの修正
- `pokemonName`の代わりに`pokemon?.name`をチェックするようにテストを更新
- テストデータに`name`プロパティを追加

## 結果
- データ構造がシンプルになり、重複が削除された
- 内部では一貫して`pokemon`オブジェクトを使用
- コードの保守性が向上

## テスト
- ✅ すべてのテストが通過
- ✅ 型チェック通過
- ✅ リントチェック通過

Closes #73