### PR TITLE
refactor: 技名（moveName）とmoveオブジェクトの変換処理を整理

### DIFF
--- a/src/tools/calculateDamage/generated/inputSchema.ts
+++ b/src/tools/calculateDamage/generated/inputSchema.ts
@@ -44,6 +44,9 @@ export const calculateDamageInputSchema = {
               type: "integer",
               minimum: 0,
             },
+            isPhysical: {
+              type: "boolean",
+            },
           },
           required: ["type", "power"],
           additionalProperties: false,

--- a/src/tools/calculateDamage/handlers/handler.ts
+++ b/src/tools/calculateDamage/handlers/handler.ts
@@ -3,6 +3,7 @@ import { calculateNormalDamage } from "./helpers/calculateDamage";
 import { getCalculatedStats } from "./helpers/calculateStats";
 import { formatError } from "./helpers/formatError";
 import { prepareCalculationContext } from "./helpers/prepareCalculationContext";
+import { resolveMove } from "./helpers/resolveMove";
 import { calculateDamageInputSchema } from "./schemas/damageSchema";
 
 /**
@@ -40,11 +41,18 @@ export const calculateDamageHandler = async (
   try {
     const input = calculateDamageInputSchema.parse(args);
 
-    const stats = getCalculatedStats(input);
-    const context = prepareCalculationContext(input);
+    // 技の解決処理を追加
+    const resolvedMove = resolveMove(input.move);
+    const inputWithResolvedMove = {
+      ...input,
+      move: resolvedMove,
+    };
+
+    const stats = getCalculatedStats(inputWithResolvedMove);
+    const context = prepareCalculationContext(inputWithResolvedMove);
 
     const damages = calculateNormalDamage(
-      input,
+      inputWithResolvedMove,
       stats.attackStat,
       stats.defenseStat,
     );

--- a/src/tools/calculateDamage/handlers/helpers/calculateDamage/calculateDamage.ts
+++ b/src/tools/calculateDamage/handlers/helpers/calculateDamage/calculateDamage.ts
@@ -6,6 +6,7 @@ import type { TypeName } from "@/types";
 import { adjustSpecialMoves } from "@/utils/adjustSpecialMoves";
 import { calculateDamageCore } from "@/utils/calculateDamageCore";
 import { calculateItemEffects } from "../itemEffects";
+import type { ResolvedMove } from "../resolveMove";
 import { getStatModifierRatio } from "../statModifier";
 
 /**
@@ -122,7 +123,7 @@ const calculateDamageInternal = (params: InternalDamageParams): number[] => {
  * 通常のダメージを計算
  */
 export const calculateNormalDamage = (
-  input: CalculateDamageInput,
+  input: CalculateDamageInput & { move: ResolvedMove },
   attackStat: number,
   defenseStat: number,
 ): number[] => {

--- a/src/tools/calculateDamage/handlers/helpers/calculateStats.ts
+++ b/src/tools/calculateDamage/handlers/helpers/calculateStats.ts
@@ -1,9 +1,10 @@
 import type { CalculateDamageInput } from "@/tools/calculateDamage/handlers/schemas/damageSchema";
 import type { CalculatedStats } from "@/tools/calculateDamage/types";
 import { getStatValue } from "./getStatValue";
+import type { ResolvedMove } from "./resolveMove";
 
 export const getCalculatedStats = (
-  input: CalculateDamageInput,
+  input: CalculateDamageInput & { move: ResolvedMove },
 ): CalculatedStats => {
   const attackStat = getStatValue({
     stat: input.attacker.stat,

--- a/src/tools/calculateDamage/handlers/helpers/prepareCalculationContext.ts
+++ b/src/tools/calculateDamage/handlers/helpers/prepareCalculationContext.ts
@@ -28,20 +28,12 @@ interface PokemonInfo {
   statModifier: number;
 }
 
-const prepareMoveInfo = (input: CalculateDamageInput): MoveInfo => {
-  if ("name" in input.move) {
-    return {
-      name: input.move.name,
-      type: input.move.type,
-      power: input.move.power,
-      isPhysical: input.move.isPhysical,
-    };
-  }
-
+const prepareMoveInfo = (move: MoveInfo): MoveInfo => {
   return {
-    type: input.move.type,
-    power: input.move.power,
-    isPhysical: input.move.isPhysical,
+    name: move.name,
+    type: move.type,
+    power: move.power,
+    isPhysical: move.isPhysical,
   };
 };
 
@@ -74,7 +66,7 @@ const checkStab = (
  * ダメージ計算に必要な共通情報を準備
  */
 export const prepareCalculationContext = (
-  input: CalculateDamageInput,
+  input: CalculateDamageInput & { move: MoveInfo },
 ): DamageCalculationContext => {
   const defenderTypes = input.defender.pokemon?.types || [];
   if (defenderTypes.length === 0) {
@@ -89,7 +81,7 @@ export const prepareCalculationContext = (
   const isStab = checkStab(input.attacker.pokemon?.types, input.move.type);
 
   return {
-    move: prepareMoveInfo(input),
+    move: prepareMoveInfo(input.move),
     attacker: preparePokemonInfo(input.attacker),
     defender: preparePokemonInfo(input.defender),
     typeEffectiveness,

--- a/src/tools/calculateDamage/handlers/helpers/resolveMove.spec.ts
+++ b/src/tools/calculateDamage/handlers/helpers/resolveMove.spec.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import type { TypeName } from "@/types";
+import { resolveMove } from "./resolveMove";
+
+describe("resolveMove", () => {
+  describe("技名から変換", () => {
+    it("存在する技名を正しく解決できる", () => {
+      const result = resolveMove("１０まんボルト");
+      expect(result).toEqual({
+        name: "１０まんボルト",
+        type: "でんき",
+        power: 95,
+        isPhysical: false,
+      });
+    });
+
+    it("物理技を正しく判定する", () => {
+      const result = resolveMove("アイアンテール");
+      expect(result).toEqual({
+        name: "アイアンテール",
+        type: "はがね",
+        power: 100,
+        isPhysical: true,
+      });
+    });
+
+    it("存在しない技名はエラーになる", () => {
+      expect(() => resolveMove("存在しない技")).toThrow(
+        "わざ「存在しない技」が見つかりません",
+      );
+    });
+
+    it("未対応の威力不定技はエラーになる", () => {
+      const unsupportedMoves = [
+        "ころがる",
+        "れんぞくぎり",
+        "アイスボール",
+        "いかり",
+        "しおふき",
+        "ふんか",
+        "マグニチュード",
+        "プレゼント",
+        "トリプルキック",
+        "めざめるパワー",
+        "はきだす",
+        "サイコウェーブ",
+        "ふくろだたき",
+        "みらいよち",
+        "はめつのねがい",
+      ];
+
+      for (const moveName of unsupportedMoves) {
+        expect(() => resolveMove(moveName)).toThrow(
+          `${moveName}には対応していません`,
+        );
+      }
+    });
+  });
+
+  describe("カスタム技", () => {
+    it("タイプと威力から技を作成できる", () => {
+      const result = resolveMove({
+        type: "ほのお",
+        power: 80,
+      });
+      expect(result).toEqual({
+        type: "ほのお",
+        power: 80,
+        isPhysical: false, // ほのおタイプなので特殊
+      });
+    });
+
+    it("isPhysicalを明示的に指定できる", () => {
+      const result = resolveMove({
+        type: "ほのお",
+        power: 80,
+        isPhysical: true,
+      });
+      expect(result).toEqual({
+        type: "ほのお",
+        power: 80,
+        isPhysical: true,
+      });
+    });
+
+    it("名前を指定できる", () => {
+      const result = resolveMove({
+        name: "カスタム技",
+        type: "みず",
+        power: 100,
+      });
+      expect(result).toEqual({
+        name: "カスタム技",
+        type: "みず",
+        power: 100,
+        isPhysical: false,
+      });
+    });
+
+    it("物理タイプの技を正しく判定する", () => {
+      const physicalTypes = [
+        "ノーマル",
+        "かくとう",
+        "どく",
+        "じめん",
+        "ひこう",
+        "むし",
+        "いわ",
+        "ゴースト",
+        "はがね",
+      ];
+
+      for (const type of physicalTypes) {
+        const result = resolveMove({
+          type: type as TypeName,
+          power: 80,
+        });
+        expect(result.isPhysical).toBe(true);
+      }
+    });
+
+    it("特殊タイプの技を正しく判定する", () => {
+      const specialTypes = [
+        "ほのお",
+        "みず",
+        "でんき",
+        "くさ",
+        "こおり",
+        "エスパー",
+        "ドラゴン",
+        "あく",
+      ];
+
+      for (const type of specialTypes) {
+        const result = resolveMove({
+          type: type as TypeName,
+          power: 80,
+        });
+        expect(result.isPhysical).toBe(false);
+      }
+    });
+  });
+});

--- a/src/tools/calculateDamage/handlers/helpers/resolveMove.ts
+++ b/src/tools/calculateDamage/handlers/helpers/resolveMove.ts
@@ -1,0 +1,68 @@
+import { MOVES } from "@/data/moves";
+import { UNSUPPORTED_MOVES } from "@/data/unsupportedMoves";
+import type { TypeName } from "@/types";
+
+// わざのタイプから物理技か特殊技かを判定する
+const isPhysicalType = (type: TypeName): boolean =>
+  [
+    "ノーマル",
+    "かくとう",
+    "どく",
+    "じめん",
+    "ひこう",
+    "むし",
+    "いわ",
+    "ゴースト",
+    "はがね",
+  ].includes(type);
+
+export interface ResolvedMove {
+  name?: string;
+  type: TypeName;
+  power: number;
+  isPhysical: boolean;
+}
+
+export type MoveInput =
+  | string // 技名
+  | {
+      name?: string;
+      type: TypeName;
+      power: number;
+      isPhysical?: boolean;
+    };
+
+/**
+ * 技の入力を解決して統一された形式に変換する
+ */
+export const resolveMove = (moveInput: MoveInput): ResolvedMove => {
+  // 技名で指定された場合
+  if (typeof moveInput === "string") {
+    const moveName = moveInput;
+
+    // 未対応技のチェック
+    if (UNSUPPORTED_MOVES.some((m) => m === moveName)) {
+      throw new Error(`${moveName}には対応していません`);
+    }
+
+    const move = MOVES.find((m) => m.name === moveName);
+    if (!move) {
+      throw new Error(`わざ「${moveName}」が見つかりません`);
+    }
+
+    return {
+      name: moveName,
+      type: move.type,
+      power: move.power,
+      isPhysical: isPhysicalType(move.type),
+    };
+  }
+
+  // カスタム技として指定された場合
+  return {
+    name: moveInput.name,
+    type: moveInput.type,
+    power: moveInput.power,
+    isPhysical: moveInput.isPhysical ?? isPhysicalType(moveInput.type),
+  };
+};

--- a/src/tools/calculateDamage/handlers/schemas/damageSchema/damageSchema.spec.ts
+++ b/src/tools/calculateDamage/handlers/schemas/damageSchema/damageSchema.spec.ts
@@ -3,7 +3,7 @@ import { calculateDamageInputSchema } from "./damageSchema";
 
 describe("calculateDamageInputSchema", () => {
   describe("わざの入力", () => {
-    it("技名から変換できる", () => {
+    it("技名を文字列として受け取れる", () => {
       const input = {
         move: "１０まんボルト",
         attacker: {
@@ -15,12 +15,7 @@ describe("calculateDamageInputSchema", () => {
       };
 
       const result = calculateDamageInputSchema.parse(input);
-      expect(result.move).toEqual({
-        name: "１０まんボルト",
-        type: "でんき",
-        power: 95,
-        isPhysical: false,
-      });
+      expect(result.move).toEqual("１０まんボルト");
     });
 
     it("タイプと威力を直接指定できる", () => {
@@ -41,13 +36,16 @@ describe("calculateDamageInputSchema", () => {
       expect(result.move).toEqual({
         type: "ほのお",
         power: 80,
-        isPhysical: false,
       });
     });
 
-    it("存在しない技名はエラーになる", () => {
+    it("カスタム技にisPhysicalを指定できる", () => {
       const input = {
-        move: "存在しない技",
+        move: {
+          type: "ほのお",
+          power: 80,
+          isPhysical: true,
+        },
         attacker: {
           stat: { value: 100 },
         },
@@ -56,51 +54,21 @@ describe("calculateDamageInputSchema", () => {
         },
       };
 
-      expect(() => calculateDamageInputSchema.parse(input)).toThrow(
-        "わざ「存在しない技」が見つかりません",
-      );
+      const result = calculateDamageInputSchema.parse(input);
+      expect(result.move).toEqual({
+        type: "ほのお",
+        power: 80,
+        isPhysical: true,
+      });
     });
 
-    it("未対応の威力不定技はエラーになる", () => {
-      const unsupportedMoves = [
-        "ころがる",
-        "れんぞくぎり",
-        "アイスボール",
-        "いかり",
-        "しおふき",
-        "ふんか",
-        "マグニチュード",
-        "プレゼント",
-        "トリプルキック",
-        "めざめるパワー",
-        "はきだす",
-        "サイコウェーブ",
-        "ふくろだたき",
-        "みらいよち",
-        "はめつのねがい",
-      ];
-
-      for (const moveName of unsupportedMoves) {
-        const input = {
-          move: moveName,
-          attacker: {
-            stat: { value: 100 },
-          },
-          defender: {
-            stat: { value: 100 },
-          },
-        };
-
-        expect(() => calculateDamageInputSchema.parse(input)).toThrow(
-          `${moveName}には対応していません`,
-        );
-      }
-    });
-
-    it("物理技と特殊技を正しく判定する", () => {
-      // 物理技
-      const physicalInput = {
-        move: "アイアンテール",
+    it("カスタム技に名前を指定できる", () => {
+      const input = {
+        move: {
+          name: "カスタム技",
+          type: "ほのお",
+          power: 80,
+        },
         attacker: {
           stat: { value: 100 },
         },
@@ -109,22 +77,12 @@ describe("calculateDamageInputSchema", () => {
         },
       };
 
-      const physicalResult = calculateDamageInputSchema.parse(physicalInput);
-      expect(physicalResult.move.isPhysical).toBe(true);
-
-      // 特殊技
-      const specialInput = {
-        move: "１０まんボルト",
-        attacker: {
-          stat: { value: 100 },
-        },
-        defender: {
-          stat: { value: 100 },
-        },
-      };
-
-      const specialResult = calculateDamageInputSchema.parse(specialInput);
-      expect(specialResult.move.isPhysical).toBe(false);
+      const result = calculateDamageInputSchema.parse(input);
+      expect(result.move).toEqual({
+        name: "カスタム技",
+        type: "ほのお",
+        power: 80,
+      });
     });
   });
 

--- a/src/tools/calculateDamage/handlers/schemas/damageSchema/damageSchema.ts
+++ b/src/tools/calculateDamage/handlers/schemas/damageSchema/damageSchema.ts
@@ -1,76 +1,37 @@
 import { z } from "zod";
 import { ABILITIES } from "@/data/abilities";
 import { ITEMS } from "@/data/items";
-import { MOVES } from "@/data/moves";
 import { POKEMONS } from "@/data/pokemon";
-import { UNSUPPORTED_MOVES } from "@/data/unsupportedMoves";
-import type { TypeName } from "@/types";
-
-// わざのタイプから物理技か特殊技かを判定する
-const isPhysicalType = (type: TypeName): boolean =>
-  [
-    "ノーマル",
-    "かくとう",
-    "どく",
-    "じめん",
-    "ひこう",
-    "むし",
-    "いわ",
-    "ゴースト",
-    "はがね",
-  ].includes(type);
 
 // わざの入力スキーマ
 const moveInputSchema = z.union([
-  // 技名から変換
-  z
-    .string()
-    .transform((moveName) => {
-      // 未対応技のチェック
-      if (UNSUPPORTED_MOVES.some((m) => m === moveName)) {
-        throw new Error(`${moveName}には対応していません`);
-      }
-
-      const move = MOVES.find((m) => m.name === moveName);
-      if (!move) {
-        throw new Error(`わざ「${moveName}」が見つかりません`);
-      }
-      return {
-        name: moveName,
-        type: move.type,
-        power: move.power,
-        isPhysical: isPhysicalType(move.type),
-      };
-    }),
-  // タイプと威力を直接指定
-  z
-    .object({
-      name: z.string().optional(),
-      type: z.enum([
-        "ノーマル",
-        "ほのお",
-        "みず",
-        "でんき",
-        "くさ",
-        "こおり",
-        "かくとう",
-        "どく",
-        "じめん",
-        "ひこう",
-        "エスパー",
-        "むし",
-        "いわ",
-        "ゴースト",
-        "ドラゴン",
-        "あく",
-        "はがね",
-      ]),
-      power: z.number().int().min(0),
-    })
-    .transform((input) => ({
-      ...input,
-      isPhysical: isPhysicalType(input.type),
-    })),
+  // 技名
+  z.string(),
+  // カスタム技
+  z.object({
+    name: z.string().optional(),
+    type: z.enum([
+      "ノーマル",
+      "ほのお",
+      "みず",
+      "でんき",
+      "くさ",
+      "こおり",
+      "かくとう",
+      "どく",
+      "じめん",
+      "ひこう",
+      "エスパー",
+      "むし",
+      "いわ",
+      "ゴースト",
+      "ドラゴン",
+      "あく",
+      "はがね",
+    ]),
+    power: z.number().int().min(0),
+    isPhysical: z.boolean().optional(),
+  }),
 ]);
 
 // 能力値の入力スキーマ（2パターン）

--- a/src/tools/calculateDamageMatrixVaryingAttack/generated/inputSchema.ts
+++ b/src/tools/calculateDamageMatrixVaryingAttack/generated/inputSchema.ts
@@ -44,6 +44,9 @@ export const calculateDamageMatrixVaryingAttackInputSchema = {
               type: "integer",
               minimum: 0,
             },
+            isPhysical: {
+              type: "boolean",
+            },
           },
           required: ["type", "power"],
           additionalProperties: false,

--- a/src/tools/calculateDamageMatrixVaryingAttack/handlers/handler.ts
+++ b/src/tools/calculateDamageMatrixVaryingAttack/handlers/handler.ts
@@ -1,4 +1,5 @@
 import { ZodError } from "zod";
+import { resolveMove } from "@/tools/calculateDamage/handlers/helpers/resolveMove";
 import { calculateDamageWithContext } from "@/utils/calculateDamageWithContext";
 import { calculateStat } from "@/utils/calculateStat";
 import { NATURE_MODIFIER_MAP } from "@/utils/natureModifier";
@@ -23,7 +24,15 @@ export const calculateDamageMatrixVaryingAttackHandler = async (
 }> => {
   try {
     const input = calculateDamageMatrixVaryingAttackInputSchema.parse(args);
-    const results = calculateDamageMatrix(input);
+
+    // 技の解決処理を追加
+    const resolvedMove = resolveMove(input.move);
+    const inputWithResolvedMove = {
+      ...input,
+      move: resolvedMove,
+    };
+
+    const results = calculateDamageMatrix(inputWithResolvedMove);
 
     return {
       content: [
@@ -79,7 +88,9 @@ export const calculateDamageMatrixVaryingAttackHandler = async (
  * ダメージマトリックスを計算
  */
 const calculateDamageMatrix = (
-  input: CalculateDamageMatrixVaryingAttackInput,
+  input: CalculateDamageMatrixVaryingAttackInput & {
+    move: ReturnType<typeof resolveMove>;
+  },
 ): { damageMatrix: DamageMatrixEntry[] } => {
   const { move, attacker, defender, options } = input;
 

--- a/src/tools/calculateDamageMatrixVaryingAttack/handlers/schemas/damageMatrixVaryingAttackSchema/damageMatrixVaryingAttackSchema.spec.ts
+++ b/src/tools/calculateDamageMatrixVaryingAttack/handlers/schemas/damageMatrixVaryingAttackSchema/damageMatrixVaryingAttackSchema.spec.ts
@@ -3,7 +3,7 @@ import { calculateDamageMatrixVaryingAttackInputSchema } from "./damageMatrixVar
 
 describe("calculateDamageMatrixVaryingAttackInputSchema", () => {
   describe("moveスキーマ", () => {
-    it("わざ名からわざ情報に変換される", () => {
+    it("わざ名を文字列として受け取れる", () => {
       const input = {
         move: "かえんほうしゃ",
         attacker: {
@@ -17,12 +17,7 @@ describe("calculateDamageMatrixVaryingAttackInputSchema", () => {
       };
 
       const result = calculateDamageMatrixVaryingAttackInputSchema.parse(input);
-      expect(result.move).toEqual({
-        name: "かえんほうしゃ",
-        type: "ほのお",
-        power: 95,
-        isPhysical: false,
-      });
+      expect(result.move).toEqual("かえんほうしゃ");
     });
 
     it("わざオブジェクトを直接指定できる", () => {
@@ -45,8 +40,6 @@ describe("calculateDamageMatrixVaryingAttackInputSchema", () => {
       expect(result.move).toEqual({
         type: "みず",
         power: 110,
-        isPhysical: false,
-        name: undefined,
       });
     });
 
@@ -77,7 +70,9 @@ describe("calculateDamageMatrixVaryingAttackInputSchema", () => {
 
         const result =
           calculateDamageMatrixVaryingAttackInputSchema.parse(input);
-        expect(result.move.isPhysical).toBe(false);
+        // スキーマではisPhysicalを判定しないので、moveオブジェクトにはisPhysicalは含まれない
+        expect(result.move).toHaveProperty("type", type);
+        expect(result.move).toHaveProperty("power", 80);
       });
     });
   });
@@ -285,7 +280,7 @@ describe("calculateDamageMatrixVaryingAttackInputSchema", () => {
   });
 
   describe("エラーケース", () => {
-    it("存在しないわざ名でエラーになる", () => {
+    it("存在しないわざ名でもスキーマではエラーにならない", () => {
       const input = {
         move: "存在しないわざ",
         attacker: {
@@ -298,9 +293,9 @@ describe("calculateDamageMatrixVaryingAttackInputSchema", () => {
         },
       };
 
-      expect(() => {
-        calculateDamageMatrixVaryingAttackInputSchema.parse(input);
-      }).toThrow("わざ「存在しないわざ」が見つかりません");
+      // スキーマではエラーにならず、文字列として受け取る
+      const result = calculateDamageMatrixVaryingAttackInputSchema.parse(input);
+      expect(result.move).toEqual("存在しないわざ");
     });
 
     it("存在しないポケモン名でエラーになる", () => {

--- a/src/tools/calculateDamageMatrixVaryingAttack/handlers/schemas/damageMatrixVaryingAttackSchema/damageMatrixVaryingAttackSchema.ts
+++ b/src/tools/calculateDamageMatrixVaryingAttack/handlers/schemas/damageMatrixVaryingAttackSchema/damageMatrixVaryingAttackSchema.ts
@@ -1,76 +1,37 @@
 import { z } from "zod";
 import { ABILITIES } from "@/data/abilities";
 import { ITEMS } from "@/data/items";
-import { MOVES } from "@/data/moves";
 import { POKEMONS } from "@/data/pokemon";
-import { UNSUPPORTED_MOVES } from "@/data/unsupportedMoves";
-import type { TypeName } from "@/types";
-
-// わざのタイプから物理技か特殊技かを判定する
-const isPhysicalType = (type: TypeName): boolean =>
-  [
-    "ノーマル",
-    "かくとう",
-    "どく",
-    "じめん",
-    "ひこう",
-    "むし",
-    "いわ",
-    "ゴースト",
-    "はがね",
-  ].includes(type);
 
 // わざの入力スキーマ
 const moveInputSchema = z.union([
-  // 技名から変換
-  z
-    .string()
-    .transform((moveName) => {
-      // 未対応技のチェック
-      if (UNSUPPORTED_MOVES.some((m) => m === moveName)) {
-        throw new Error(`${moveName}には対応していません`);
-      }
-
-      const move = MOVES.find((m) => m.name === moveName);
-      if (!move) {
-        throw new Error(`わざ「${moveName}」が見つかりません`);
-      }
-      return {
-        name: moveName,
-        type: move.type,
-        power: move.power,
-        isPhysical: isPhysicalType(move.type),
-      };
-    }),
-  // タイプと威力を直接指定
-  z
-    .object({
-      name: z.string().optional(),
-      type: z.enum([
-        "ノーマル",
-        "ほのお",
-        "みず",
-        "でんき",
-        "くさ",
-        "こおり",
-        "かくとう",
-        "どく",
-        "じめん",
-        "ひこう",
-        "エスパー",
-        "むし",
-        "いわ",
-        "ゴースト",
-        "ドラゴン",
-        "あく",
-        "はがね",
-      ]),
-      power: z.number().int().min(0),
-    })
-    .transform((input) => ({
-      ...input,
-      isPhysical: isPhysicalType(input.type),
-    })),
+  // 技名
+  z.string(),
+  // カスタム技
+  z.object({
+    name: z.string().optional(),
+    type: z.enum([
+      "ノーマル",
+      "ほのお",
+      "みず",
+      "でんき",
+      "くさ",
+      "こおり",
+      "かくとう",
+      "どく",
+      "じめん",
+      "ひこう",
+      "エスパー",
+      "むし",
+      "いわ",
+      "ゴースト",
+      "ドラゴン",
+      "あく",
+      "はがね",
+    ]),
+    power: z.number().int().min(0),
+    isPhysical: z.boolean().optional(),
+  }),
 ]);
 
 // 攻撃側の能力値の入力スキーマ（個体値のみ）

--- a/src/tools/calculateDamageMatrixVaryingDefense/generated/inputSchema.ts
+++ b/src/tools/calculateDamageMatrixVaryingDefense/generated/inputSchema.ts
@@ -44,6 +44,9 @@ export const calculateDamageMatrixVaryingDefenseInputSchema = {
               type: "integer",
               minimum: 0,
             },
+            isPhysical: {
+              type: "boolean",
+            },
           },
           required: ["type", "power"],
           additionalProperties: false,

--- a/src/tools/calculateDamageMatrixVaryingDefense/handlers/handler.ts
+++ b/src/tools/calculateDamageMatrixVaryingDefense/handlers/handler.ts
@@ -1,4 +1,5 @@
 import { ZodError } from "zod";
+import { resolveMove } from "@/tools/calculateDamage/handlers/helpers/resolveMove";
 import { calculateDamageWithContext } from "@/utils/calculateDamageWithContext";
 import { calculateHp } from "@/utils/calculateHp";
 import { calculateStat } from "@/utils/calculateStat";
@@ -25,7 +26,15 @@ export const calculateDamageMatrixVaryingDefenseHandler = async (
 }> => {
   try {
     const input = calculateDamageMatrixVaryingDefenseInputSchema.parse(args);
-    const results = calculateDamageMatrix(input);
+
+    // 技の解決処理を追加
+    const resolvedMove = resolveMove(input.move);
+    const inputWithResolvedMove = {
+      ...input,
+      move: resolvedMove,
+    };
+
+    const results = calculateDamageMatrix(inputWithResolvedMove);
 
     return {
       content: [
@@ -81,7 +90,9 @@ export const calculateDamageMatrixVaryingDefenseHandler = async (
  * ダメージマトリックスを計算
  */
 const calculateDamageMatrix = (
-  input: CalculateDamageMatrixVaryingDefenseInput,
+  input: CalculateDamageMatrixVaryingDefenseInput & {
+    move: ReturnType<typeof resolveMove>;
+  },
 ): { damageMatrix: DamageMatrixEntry[] } => {
   const { move, attacker, defender, options } = input;
 

--- a/src/tools/calculateDamageMatrixVaryingDefense/handlers/schemas/damageMatrixVaryingDefenseSchema/damageMatrixVaryingDefenseSchema.spec.ts
+++ b/src/tools/calculateDamageMatrixVaryingDefense/handlers/schemas/damageMatrixVaryingDefenseSchema/damageMatrixVaryingDefenseSchema.spec.ts
@@ -3,7 +3,7 @@ import { calculateDamageMatrixVaryingDefenseInputSchema } from "./damageMatrixVa
 
 describe("calculateDamageMatrixVaryingDefenseInputSchema", () => {
   describe("moveスキーマ", () => {
-    it("わざ名からわざ情報に変換される", () => {
+    it("わざ名を文字列として受け取れる", () => {
       const input = {
         move: "10まんボルト",
         attacker: {
@@ -18,12 +18,7 @@ describe("calculateDamageMatrixVaryingDefenseInputSchema", () => {
 
       const result =
         calculateDamageMatrixVaryingDefenseInputSchema.parse(input);
-      expect(result.move).toEqual({
-        name: "10まんボルト",
-        type: "でんき",
-        power: 95,
-        isPhysical: false,
-      });
+      expect(result.move).toEqual("10まんボルト");
     });
 
     it("わざオブジェクトを直接指定できる", () => {
@@ -47,8 +42,6 @@ describe("calculateDamageMatrixVaryingDefenseInputSchema", () => {
       expect(result.move).toEqual({
         type: "ほのお",
         power: 120,
-        isPhysical: false,
-        name: undefined,
       });
     });
 
@@ -78,7 +71,9 @@ describe("calculateDamageMatrixVaryingDefenseInputSchema", () => {
 
         const result =
           calculateDamageMatrixVaryingDefenseInputSchema.parse(input);
-        expect(result.move.isPhysical).toBe(true);
+        // スキーマではisPhysicalを判定しないので、moveオブジェクトにはisPhysicalは含まれない
+        expect(result.move).toHaveProperty("type", type);
+        expect(result.move).toHaveProperty("power", 80);
       });
     });
   });
@@ -272,7 +267,7 @@ describe("calculateDamageMatrixVaryingDefenseInputSchema", () => {
   });
 
   describe("エラーケース", () => {
-    it("存在しないわざ名でエラーになる", () => {
+    it("存在しないわざ名でもスキーマではエラーにならない", () => {
       const input = {
         move: "存在しないわざ",
         attacker: {
@@ -285,9 +280,10 @@ describe("calculateDamageMatrixVaryingDefenseInputSchema", () => {
         },
       };
 
-      expect(() => {
+      // スキーマではエラーにならず、文字列として受け取る
+      const result =
         calculateDamageMatrixVaryingDefenseInputSchema.parse(input);
-      }).toThrow("わざ「存在しないわざ」が見つかりません");
+      expect(result.move).toEqual("存在しないわざ");
     });
 
     it("努力値が範囲外でエラーになる", () => {

--- a/src/tools/calculateDamageMatrixVaryingDefense/handlers/schemas/damageMatrixVaryingDefenseSchema/damageMatrixVaryingDefenseSchema.ts
+++ b/src/tools/calculateDamageMatrixVaryingDefense/handlers/schemas/damageMatrixVaryingDefenseSchema/damageMatrixVaryingDefenseSchema.ts
@@ -1,76 +1,37 @@
 import { z } from "zod";
 import { ABILITIES } from "@/data/abilities";
 import { ITEMS } from "@/data/items";
-import { MOVES } from "@/data/moves";
 import { POKEMONS } from "@/data/pokemon";
-import { UNSUPPORTED_MOVES } from "@/data/unsupportedMoves";
-import type { TypeName } from "@/types";
-
-// わざのタイプから物理技か特殊技かを判定する
-const isPhysicalType = (type: TypeName): boolean =>
-  [
-    "ノーマル",
-    "かくとう",
-    "どく",
-    "じめん",
-    "ひこう",
-    "むし",
-    "いわ",
-    "ゴースト",
-    "はがね",
-  ].includes(type);
 
 // わざの入力スキーマ
 const moveInputSchema = z.union([
-  // 技名から変換
-  z
-    .string()
-    .transform((moveName) => {
-      // 未対応技のチェック
-      if (UNSUPPORTED_MOVES.some((m) => m === moveName)) {
-        throw new Error(`${moveName}には対応していません`);
-      }
-
-      const move = MOVES.find((m) => m.name === moveName);
-      if (!move) {
-        throw new Error(`わざ「${moveName}」が見つかりません`);
-      }
-      return {
-        name: moveName,
-        type: move.type,
-        power: move.power,
-        isPhysical: isPhysicalType(move.type),
-      };
-    }),
-  // タイプと威力を直接指定
-  z
-    .object({
-      name: z.string().optional(),
-      type: z.enum([
-        "ノーマル",
-        "ほのお",
-        "みず",
-        "でんき",
-        "くさ",
-        "こおり",
-        "かくとう",
-        "どく",
-        "じめん",
-        "ひこう",
-        "エスパー",
-        "むし",
-        "いわ",
-        "ゴースト",
-        "ドラゴン",
-        "あく",
-        "はがね",
-      ]),
-      power: z.number().int().min(0),
-    })
-    .transform((input) => ({
-      ...input,
-      isPhysical: isPhysicalType(input.type),
-    })),
+  // 技名
+  z.string(),
+  // カスタム技
+  z.object({
+    name: z.string().optional(),
+    type: z.enum([
+      "ノーマル",
+      "ほのお",
+      "みず",
+      "でんき",
+      "くさ",
+      "こおり",
+      "かくとう",
+      "どく",
+      "じめん",
+      "ひこう",
+      "エスパー",
+      "むし",
+      "いわ",
+      "ゴースト",
+      "ドラゴン",
+      "あく",
+      "はがね",
+    ]),
+    power: z.number().int().min(0),
+    isPhysical: z.boolean().optional(),
+  }),
 ]);
 
 // 攻撃側の能力値の入力スキーマ（固定値のみ）


### PR DESCRIPTION
## Summary
- スキーマでの暗黙的な技名→Moveオブジェクト変換を削除し、明示的な変換処理に変更
- `resolveMove`関数を新規作成し、技の解決処理を一元化
- 全ツール（calculateDamage、calculateDamageMatrixVaryingAttack/Defense）で統一的な処理に

## Test plan
- [x] 全テストが通過することを確認
- [x] 型チェック・リントエラーがないことを確認
- [x] 既存の技名入力・カスタム技入力の両方が正しく動作することを確認

Closes #74