### PR TITLE
refactor: せいかくをstring型からNatureName型に変更して型安全性を向上

### DIFF
--- a/src/tools/calculateStatus/handlers/handler.spec.ts
+++ b/src/tools/calculateStatus/handlers/handler.spec.ts
@@ -64,7 +64,7 @@ describe("calculate-status tool", () => {
     const output = parseResponse<CalculateStatusErrorOutput>(result);
     expect("error" in output).toBe(true);
     if ("error" in output) {
-      expect(output.error).toContain("せいかく「つよき」が見つかりません");
+      expect(output.error).toContain("無効なせいかくです");
     }
   });
 

--- a/src/tools/calculateStatus/handlers/handlerErrorTest.spec.ts
+++ b/src/tools/calculateStatus/handlers/handlerErrorTest.spec.ts
@@ -52,9 +52,7 @@ describe("calculateStatusHandler エラーハンドリング", () => {
     const output = parseResponse<{ error: string }>(result);
     expect("error" in output).toBe(true);
     if ("error" in output) {
-      expect(output.error).toContain(
-        "せいかく「無効なせいかく」が見つかりません",
-      );
+      expect(output.error).toContain("無効なせいかくです");
     }
   });
 

--- a/src/tools/calculateStatus/handlers/schemas/statusSchema/statusSchema.spec.ts
+++ b/src/tools/calculateStatus/handlers/schemas/statusSchema/statusSchema.spec.ts
@@ -181,7 +181,7 @@ describe("calculateStatusInputSchema", () => {
       };
 
       expect(() => calculateStatusInputSchema.parse(input)).toThrow(
-        "せいかく「存在しないせいかく」が見つかりません",
+        "無効なせいかくです",
       );
     });
   });

--- a/src/tools/calculateStatus/handlers/schemas/statusSchema/statusSchema.ts
+++ b/src/tools/calculateStatus/handlers/schemas/statusSchema/statusSchema.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { NATURES } from "@/data/natures";
+import { NATURES, type NatureName } from "@/data/natures";
 import { POKEMONS } from "@/data/pokemon";
 
 // 個体値のスキーマ
@@ -42,7 +42,12 @@ export const calculateStatusInputSchema = z
       .string()
       .describe('ポケモン名（例: "フシギダネ"、"メタグロス"）'),
     level: z.number().int().min(1).max(100).describe("レベル（1-100）"),
-    nature: z.string().describe('せいかく（例: "いじっぱり"、"ひかえめ"）'),
+    nature: z
+      .string()
+      .refine((val): val is NatureName => NATURES.some((n) => n.name === val), {
+        message: "無効なせいかくです",
+      })
+      .describe('せいかく（例: "いじっぱり"、"ひかえめ"）'),
     ivs: ivsSchema,
     evs: evsSchema,
   })


### PR DESCRIPTION
## Summary
- せいかくの型をstring型からNatureName型に変更
- Zodスキーマで厳密な型チェックを実装
- 無効なせいかくを指定した場合にコンパイル時・実行時の両方でエラーが検出されるように改善

## Changes
- `calculateStatus`スキーマで`NatureName`型を使用するよう更新
- Zodの`refine`メソッドで型ガードを追加し、実行時の型安全性を確保
- 無効なせいかくの場合のエラーメッセージを「無効なせいかくです」に統一
- 関連するテストのエラーメッセージ期待値を更新

## Benefits
1. **コンパイル時の型チェック**: 無効なせいかくを指定した場合、TypeScriptがエラーを出す
2. **IDE支援**: 自動補完で有効なせいかくの一覧が表示される（クライアント側での実装に依存）
3. **リファクタリング安全性**: せいかく名を変更する際、全ての参照箇所が自動的に検出される
4. **ドキュメント性**: 型定義を見れば有効なせいかくの一覧が分かる

## Test plan
- [x] `npm run typecheck` - 型チェックが通ること
- [x] `npm run lint` - リントが通ること
- [x] `npm run test` - 全てのテストが通ること
- [x] `npm run check` - 全てのチェックが通ること

Closes #75