### PR TITLE
refactor: calculateDamageInternalとcalculateDamageWithContextの重複を解消

### DIFF
--- a/src/tools/calculateDamage/handlers/helpers/calculateDamage/calculateDamage.ts
+++ b/src/tools/calculateDamage/handlers/helpers/calculateDamage/calculateDamage.ts
@@ -1,123 +1,6 @@
-import type { Ability } from "@/data/abilities";
-import type { Item } from "@/data/items";
 import type { CalculateDamageInput } from "@/tools/calculateDamage/handlers/schemas/damageSchema";
-import type { DamageOptions } from "@/tools/calculateDamage/types";
-import type { TypeName } from "@/types";
-import { adjustSpecialMoves } from "@/utils/adjustSpecialMoves";
-import { calculateDamageCore } from "@/utils/calculateDamageCore";
-import { calculateItemEffects } from "../itemEffects";
+import { calculateDamageWithContext } from "@/utils/calculateDamageWithContext";
 import type { ResolvedMove } from "../resolveMove";
-import { getStatModifierRatio } from "../statModifier";
-
-/**
- * 内部的なダメージ計算パラメータ
- */
-interface InternalDamageParams {
-  move: {
-    name?: string;
-    type: TypeName;
-    power: number;
-    isPhysical: boolean;
-  };
-  attacker: {
-    level: number;
-    attack: number;
-    attackModifier: number;
-    types?: TypeName[];
-    pokemon?: { name: string };
-    ability?: Ability;
-    abilityActive?: boolean;
-    item?: Item;
-  };
-  defender: {
-    defense: number;
-    defenseModifier: number;
-    types: TypeName[];
-    pokemon?: { name: string };
-    ability?: Ability;
-    abilityActive?: boolean;
-    item?: Item;
-  };
-  options: DamageOptions;
-}
-
-/**
- * ダメージ計算の主処理
- * 補正値、タイプ相性、とくせい効果を全て適用
- */
-const calculateDamageInternal = (params: InternalDamageParams): number[] => {
-  const { move, attacker, defender, options } = params;
-
-  const attackerItemEffects = calculateItemEffects(
-    attacker.item,
-    attacker.pokemon?.name,
-    move.type,
-    move.isPhysical,
-  );
-
-  const defenderItemEffects = calculateItemEffects(
-    defender.item,
-    defender.pokemon?.name,
-    move.type,
-    move.isPhysical,
-  );
-
-  const attackRatio = getStatModifierRatio(attacker.attackModifier);
-  const baseAttackStat = Math.floor(
-    (attacker.attack * attackRatio.numerator) / attackRatio.denominator,
-  );
-
-  const attackStat = move.isPhysical
-    ? Math.floor(
-        (baseAttackStat * attackerItemEffects.attackMultiplier.numerator) /
-          attackerItemEffects.attackMultiplier.denominator,
-      )
-    : Math.floor(
-        (baseAttackStat *
-          attackerItemEffects.specialAttackMultiplier.numerator) /
-          attackerItemEffects.specialAttackMultiplier.denominator,
-      );
-
-  const defenseRatio = getStatModifierRatio(defender.defenseModifier);
-  const baseDefenseStat = Math.floor(
-    (defender.defense * defenseRatio.numerator) / defenseRatio.denominator,
-  );
-
-  const defenseStat = move.isPhysical
-    ? Math.floor(
-        (baseDefenseStat * defenderItemEffects.defenseMultiplier.numerator) /
-          defenderItemEffects.defenseMultiplier.denominator,
-      )
-    : Math.floor(
-        (baseDefenseStat *
-          defenderItemEffects.specialDefenseMultiplier.numerator) /
-          defenderItemEffects.specialDefenseMultiplier.denominator,
-      );
-
-  // 共通ロジックを使用
-  return calculateDamageCore({
-    move: {
-      name: move.name,
-      type: move.type,
-      power: move.power,
-      isPhysical: move.isPhysical,
-    },
-    attacker: {
-      level: attacker.level,
-      attackStat,
-      types: attacker.types,
-      ability: attacker.ability,
-      abilityActive: attacker.abilityActive,
-    },
-    defender: {
-      defenseStat,
-      types: defender.types,
-      ability: defender.ability,
-      abilityActive: defender.abilityActive,
-    },
-    options,
-  });
-};
 
 /**
  * 通常のダメージを計算
@@ -127,45 +10,25 @@ export const calculateNormalDamage = (
   attackStat: number,
   defenseStat: number,
 ): number[] => {
-  const defenderTypes = input.defender.pokemon?.types || [];
-
-  // 特殊な技の処理
-  const adjustedMove = adjustSpecialMoves({
+  return calculateDamageWithContext({
     move: input.move,
-    weather: input.options?.weather,
-    defenderWeight: input.defender.pokemon?.weightkg,
-  });
-
-  return calculateDamageInternal({
-    move: {
-      name: adjustedMove.name,
-      type: adjustedMove.type,
-      power: adjustedMove.power,
-      isPhysical: adjustedMove.isPhysical,
-    },
+    attackStat,
+    defenseStat,
     attacker: {
       level: input.attacker.level,
-      attack: attackStat,
-      attackModifier: input.attacker.statModifier,
-      types: input.attacker.pokemon?.types,
-      pokemon: input.attacker.pokemon
-        ? { name: input.attacker.pokemon.name }
-        : undefined,
+      statModifier: input.attacker.statModifier,
+      pokemon: input.attacker.pokemon,
       ability: input.attacker.ability,
       abilityActive: input.attacker.abilityActive,
       item: input.attacker.item,
     },
     defender: {
-      defense: defenseStat,
-      defenseModifier: input.defender.statModifier,
-      types: defenderTypes,
-      pokemon: input.defender.pokemon
-        ? { name: input.defender.pokemon.name }
-        : undefined,
+      statModifier: input.defender.statModifier,
+      pokemon: input.defender.pokemon,
       ability: input.defender.ability,
       abilityActive: input.defender.abilityActive,
       item: input.defender.item,
     },
-    options: input.options || {},
+    options: input.options,
   });
 };


### PR DESCRIPTION
## Summary
- similarity-tsで検出された92.10%の重複コードを解消
- `calculateDamageInternal`を削除し、既存の`calculateDamageWithContext`を使用するように変更
- 137行のコード削減を達成（146行削除、9行追加）

## 変更内容
- `src/tools/calculateDamage/handlers/helpers/calculateDamage/calculateDamage.ts`
  - `calculateDamageInternal`関数とその関連する型定義を削除
  - `calculateNormalDamage`を`calculateDamageWithContext`を使用するように修正

## テスト結果
- ✅ 全220件のユニットテストが成功
- ✅ 型チェック成功
- ✅ 統合テスト成功
- ✅ リントチェック成功

## 影響範囲
- 機能的な変更はありません
- 内部実装の重複を解消したのみで、外部APIの変更はありません