### PR TITLE
feat: npxで実行可能なnpmパッケージとして公開するための設定を追加

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,48 @@
+# Development files
+src/
+scripts/
+tests/
+*.spec.ts
+*.test.ts
+
+# Configuration files
+biome.json
+tsconfig.json
+vitest.config.ts
+renovate.json
+
+# Build artifacts
+coverage/
+.cache/
+
+# Documentation for development
+docs/
+CLAUDE.md
+
+# Git
+.git/
+.gitignore
+
+# Node
+node_modules/
+npm-debug.log*
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Temporary files
+*.tmp
+*.temp
+.env.local
+.env.development
+
+# Example files
+*.example
+examples/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 ptrst102
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,17 @@
 
 ## インストール
 
+### npmパッケージとして使用（推奨）
+
+このMCPサーバーはnpmパッケージとして公開されているため、npxを使用して直接実行できます：
+
+```bash
+# インストール不要で直接使用可能
+npx pokemon-gen3-calc-mcp
+```
+
+### ローカルでの開発
+
 ```bash
 # リポジトリのクローン
 git clone https://github.com/ptrst102/pokemon-gen3-calc-mcp.git
@@ -45,11 +56,31 @@ cd pokemon-gen3-calc-mcp
 
 # 依存関係のインストール
 npm install
+
+# ビルド
+npm run build
 ```
 
 ## 使い方
 
 ### MCP クライアントとの連携
+
+#### npx を使用する場合（推奨）
+
+MCP クライアント（Claude Desktop など）の設定ファイルに以下を追加：
+
+```json
+{
+  "mcpServers": {
+    "pokemon-gen3-calc": {
+      "command": "npx",
+      "args": ["-y", "pokemon-gen3-calc-mcp"]
+    }
+  }
+}
+```
+
+#### ローカルビルドを使用する場合
 
 1. ビルドを実行して dist ディレクトリにファイルを生成：
 
@@ -57,7 +88,7 @@ npm install
 npm run build
 ```
 
-2. MCP クライアント（Claude Desktop など）の設定ファイルに以下を追加：
+2. MCP クライアントの設定ファイルに以下を追加：
 
 ```json
 {

--- a/docs/npm-package-guide.md
+++ b/docs/npm-package-guide.md
@@ -1,0 +1,253 @@
+# npxで実行可能なMCPサーバーパッケージの作成ガイド
+
+このドキュメントでは、MCPサーバーをnpxで実行可能なnpmパッケージとして公開する方法について説明します。
+
+## 概要
+
+MCPサーバーをnpxで実行可能にすることで、ユーザーは以下のメリットを得られます：
+
+- インストール不要で即座に利用可能
+- 常に最新バージョンを使用
+- グローバルインストールによる環境汚染を回避
+- MCP設定ファイルでの記述がシンプルになる
+
+## 必要な設定
+
+### 1. package.jsonの設定
+
+#### binフィールド
+
+実行可能ファイルを指定します：
+
+```json
+{
+  "bin": {
+    "pokemon-gen3-calc-mcp": "./dist/index.js"
+  }
+}
+```
+
+- キー（`pokemon-gen3-calc-mcp`）: npxで実行する際のコマンド名
+- 値（`./dist/index.js`）: 実行されるファイルのパス
+
+#### filesフィールド
+
+npmパッケージに含めるファイルを指定します：
+
+```json
+{
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "package.json"
+  ]
+}
+```
+
+#### mainフィールド（オプション）
+
+パッケージのエントリーポイントを指定します：
+
+```json
+{
+  "main": "./dist/index.js"
+}
+```
+
+### 2. ビルドスクリプトの設定
+
+ビルドスクリプト（`scripts/build.ts`）で以下を確認：
+
+1. **shebangの追加**
+   ```javascript
+   banner: {
+     js: "#!/usr/bin/env node",
+   }
+   ```
+
+2. **実行権限の設定**
+   ```javascript
+   await chmod("dist/index.js", 0o755);
+   ```
+
+### 3. .npmignoreファイル
+
+開発用ファイルを公開から除外します：
+
+```
+# Development files
+src/
+scripts/
+tests/
+*.spec.ts
+*.test.ts
+
+# Configuration files
+biome.json
+tsconfig.json
+vitest.config.ts
+renovate.json
+
+# Build artifacts
+coverage/
+.cache/
+
+# Documentation for development
+docs/
+CLAUDE.md
+
+# Git
+.git/
+.gitignore
+
+# Node
+node_modules/
+npm-debug.log*
+```
+
+## npm公開手順
+
+### 1. npmアカウントの準備
+
+```bash
+# npmにログイン
+npm login
+```
+
+### 2. パッケージ名の確認
+
+```bash
+# パッケージ名が利用可能か確認
+npm view pokemon-gen3-calc-mcp
+```
+
+既に使用されている場合は、package.jsonの`name`フィールドを変更する必要があります。
+
+### 3. ビルドとテスト
+
+```bash
+# ビルド
+npm run build
+
+# テストの実行
+npm run check
+
+# ローカルでのテスト（グローバルリンク）
+npm link
+
+# 別のディレクトリで実行テスト
+npx pokemon-gen3-calc-mcp
+```
+
+### 4. バージョン管理
+
+```bash
+# パッチバージョンアップ（1.0.0 → 1.0.1）
+npm version patch
+
+# マイナーバージョンアップ（1.0.0 → 1.1.0）
+npm version minor
+
+# メジャーバージョンアップ（1.0.0 → 2.0.0）
+npm version major
+```
+
+### 5. 公開
+
+```bash
+# 公開（初回）
+npm publish
+
+# 公開（更新）
+npm publish
+```
+
+### 6. 公開後の確認
+
+```bash
+# パッケージ情報の確認
+npm view pokemon-gen3-calc-mcp
+
+# npxでの実行テスト
+npx pokemon-gen3-calc-mcp
+```
+
+## スコープ付きパッケージ（オプション）
+
+組織やユーザー名でスコープを付けることも可能です：
+
+```json
+{
+  "name": "@username/pokemon-gen3-calc-mcp"
+}
+```
+
+スコープ付きパッケージを公開する場合：
+
+```bash
+# パブリック公開
+npm publish --access public
+```
+
+## MCPクライアントでの使用方法
+
+### Claude Desktopの設定例
+
+```json
+{
+  "mcpServers": {
+    "pokemon-gen3-calc": {
+      "command": "npx",
+      "args": ["-y", "pokemon-gen3-calc-mcp"]
+    }
+  }
+}
+```
+
+- `-y`オプション: 確認プロンプトをスキップして自動的に実行
+
+## トラブルシューティング
+
+### 実行ファイルが見つからない場合
+
+1. `dist/index.js`が存在することを確認
+2. shebangが正しく設定されているか確認
+3. 実行権限が設定されているか確認
+
+### パッケージが古いバージョンを使用する場合
+
+```bash
+# キャッシュをクリア
+npx clear-npx-cache
+```
+
+### 公開エラーが発生する場合
+
+1. npmにログインしているか確認
+2. パッケージ名が重複していないか確認
+3. バージョンが既に公開されていないか確認
+
+## ベストプラクティス
+
+1. **セマンティックバージョニング**を遵守
+   - 破壊的変更: メジャーバージョン
+   - 新機能追加: マイナーバージョン
+   - バグ修正: パッチバージョン
+
+2. **CHANGELOGの維持**
+   - 各リリースの変更内容を記録
+
+3. **プレリリースのテスト**
+   ```bash
+   npm publish --tag beta
+   ```
+
+4. **GitHub Actionsでの自動公開**
+   - タグプッシュ時に自動的にnpm公開
+
+## 参考リンク
+
+- [npm公式ドキュメント](https://docs.npmjs.com/)
+- [MCP公式ドキュメント](https://github.com/anthropics/model-context-protocol)
+- [セマンティックバージョニング](https://semver.org/)

--- a/package.json
+++ b/package.json
@@ -3,6 +3,16 @@
   "version": "1.0.0",
   "description": "Pokemon Generation 3 damage and status calculator MCP server",
   "type": "module",
+  "main": "./dist/index.js",
+  "bin": {
+    "pokemon-gen3-calc-mcp": "./dist/index.js"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "package.json"
+  ],
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "build": "tsx scripts/build.ts",


### PR DESCRIPTION
## 概要

このPRでは、MCPサーバーをnpxで実行可能なnpmパッケージとして公開するための設定を追加しました。

## 変更内容

- **package.json**: `bin`、`files`、`main`フィールドを追加
- **.npmignore**: 開発用ファイルを公開から除外する設定を追加
- **LICENSE**: MITライセンスファイルを追加
- **README.md**: npxでの使用方法を追加
- **docs/npm-package-guide.md**: npmパッケージ公開の詳細なガイドを作成

## 使用方法

npmに公開後、以下のようにnpxで直接実行できるようになります：

```bash
npx pokemon-gen3-calc-mcp
```

MCPクライアント（Claude Desktop等）での設定：

```json
{
  "mcpServers": {
    "pokemon-gen3-calc": {
      "command": "npx",
      "args": ["-y", "pokemon-gen3-calc-mcp"]
    }
  }
}
```

## テスト結果

- ✅ ビルド成功（`npm run build`）
- ✅ 型チェック成功（`npm run typecheck`）
- ✅ リント成功（`npm run lint`）
- ✅ 全テスト成功（`npm run test`）
- ✅ npm linkでのローカルテスト成功

## 次のステップ

1. このPRをマージ
2. `npm publish`でnpmに公開
3. ユーザーが`npx pokemon-gen3-calc-mcp`で利用開始